### PR TITLE
Using multi time series + per serie specific exogenous features

### DIFF
--- a/skforecast/ForecasterAutoregMultiSeries/tests/test_create_train_X_y.py
+++ b/skforecast/ForecasterAutoregMultiSeries/tests/test_create_train_X_y.py
@@ -151,7 +151,7 @@ def test_create_train_X_y_ValueError_when_series_values_are_missing(values):
     series = pd.DataFrame({'1': pd.Series(values), 
                            '2': pd.Series(np.arange(7))})
     series.index = pd.date_range(start='2022-01-01', periods=7, freq='1D')
-    forecaster = ForecasterAutoregMultiSeries(LinearRegression(), lags=5)
+    forecaster = ForecasterAutoregMultiSeries(LinearRegression(), lags=2)
 
     err_msg = re.escape(
                 ("'1' Time series has missing values in between or "
@@ -161,6 +161,32 @@ def test_create_train_X_y_ValueError_when_series_values_are_missing(values):
               )
     with pytest.raises(ValueError, match = err_msg):
         forecaster.create_train_X_y(series=series)
+
+
+# TODO : add serie test 
+@pytest.mark.parametrize("exog", 
+                         [pd.DataFrame(np.arange(10, 24).reshape(7, 2))])
+def test_create_train_X_y_output_when_series_and_exog_per_serie_is_defined(exog):
+    """
+    Test ValueError is raised when length of series is not equal to length exog.
+    """
+    series = pd.DataFrame({'1': pd.Series(np.arange(7)), 
+                           '2': pd.Series(np.arange(7))})
+
+    exog_per_serie = {
+        "1": pd.DataFrame({
+            "X1" : np.arange(100, 107), 
+            "X2" : np.arange(200, 207)
+        }),
+        "2": pd.DataFrame({
+            "X1" : np.arange(300, 307), 
+            "X2" : np.arange(400, 407)
+        }),
+    }
+
+    forecaster = ForecasterAutoregMultiSeries(LinearRegression(), lags=5)
+    forecaster.create_train_X_y(series=series, exog=exog, exog_per_serie=exog_per_serie)
+
 
 
 def test_create_train_X_y_output_when_series_and_exog_is_None():

--- a/skforecast/utils/utils.py
+++ b/skforecast/utils/utils.py
@@ -288,6 +288,45 @@ def check_exog(
     return
 
 
+def check_exog_per_serie(
+    exog_per_serie: Any,
+    allow_nan: bool=True
+) -> None:
+    """
+    Raise Exception if `exog` is not a dictionary with at least one key and either a pandas Series or Dataframe as value.
+    If `allow_nan = True`, issue a warning if `exog` contains NaN values.
+    
+    Parameters
+    ----------
+    exog_per_serie : Any
+        Exogenous variable/s included as predictor/s.
+    allow_nan : bool, default `True`
+        If True, allows the presence of NaN values in `exog`. If False (default),
+        issue a warning if `exog` contains NaN values.
+
+    Returns
+    -------
+    None
+
+    """
+    
+    if not isinstance(exog_per_serie, dict):
+        raise TypeError(f"`exog_per_serie` must be a dict. Got {type(exog_per_serie)}")
+
+    if not allow_nan:
+        if exog_per_serie.isnull().any().any():
+            warnings.warn(
+                ("`exog_per_serie` has missing values. Most machine learning models do not allow "
+                 "missing values. Fitting the forecaster may fail."), 
+                 MissingValuesExogWarning
+            )
+
+    for value in exog_per_serie.values(): 
+        if not isinstance(value,  (pd.Series, pd.DataFrame)):
+            raise TypeError("The values of `exog_per_serie` should be pandas Series or pandas DataFrame.")
+    return
+
+
 def get_exog_dtypes(
     exog: Union[pd.DataFrame, pd.Series]
 ) -> dict:


### PR DESCRIPTION
Hi again, 

What I am trying to solve : It is impossible to use per serie feature values with multi serie models 

Let's assume a dataframe with columns id - X1 - y. id being my unique identifer for my serie, X1 being my serie specific feature and y being my target. 

When preparing my data for ForecasterAutoregMultiSeries, I have to create a dataframe where each column 
is the y value for a specific id (i.e id_1, ..., id_K) 

The current exog parameter of the ForecasterAutoregMultiSeries.fit function does not treat X1 as a per serie feature, meaning that each unique time serie would have a specific value for X1, but instead treat X1 as a general value (when id_1 , ..., id_K happened, X1 happened as well).

Here is my fix for this major inconvenience. 

I did not elaborate on tests because I am pretty sure there MUST BE a way of doing what I was looking for 6 hours already implemented by you guys, I just wanted to make sure. 

Best, 

Valentin