### PR TITLE
added copy last_window in predict

### DIFF
--- a/skforecast/ForecasterAutoreg/ForecasterAutoreg.py
+++ b/skforecast/ForecasterAutoreg/ForecasterAutoreg.py
@@ -641,7 +641,9 @@ class ForecasterAutoreg(ForecasterBase):
         """
 
         if last_window is None:
-            last_window = copy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         check_predict_input(
             forecaster_name  = type(self).__name__,
@@ -785,7 +787,9 @@ class ForecasterAutoreg(ForecasterBase):
             )
 
         if last_window is None:
-            last_window = copy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         check_predict_input(
             forecaster_name  = type(self).__name__,

--- a/skforecast/ForecasterAutoregCustom/ForecasterAutoregCustom.py
+++ b/skforecast/ForecasterAutoregCustom/ForecasterAutoregCustom.py
@@ -664,7 +664,9 @@ class ForecasterAutoregCustom(ForecasterBase):
         """
 
         if last_window is None:
-            last_window = copy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         last_window = last_window.iloc[-self.window_size:]
 
@@ -810,7 +812,9 @@ class ForecasterAutoregCustom(ForecasterBase):
             )
 
         if last_window is None:
-            last_window = copy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         check_predict_input(
             forecaster_name  = type(self).__name__,

--- a/skforecast/ForecasterAutoregDirect/ForecasterAutoregDirect.py
+++ b/skforecast/ForecasterAutoregDirect/ForecasterAutoregDirect.py
@@ -775,7 +775,9 @@ class ForecasterAutoregDirect(ForecasterBase):
                 )
 
         if last_window is None:
-            last_window = copy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         check_predict_input(
             forecaster_name  = type(self).__name__,

--- a/skforecast/ForecasterAutoregMultiSeries/ForecasterAutoregMultiSeries.py
+++ b/skforecast/ForecasterAutoregMultiSeries/ForecasterAutoregMultiSeries.py
@@ -845,7 +845,9 @@ class ForecasterAutoregMultiSeries(ForecasterBase):
             levels = [levels]
 
         if last_window is None:
-            last_window = deepcopy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
         
         check_predict_input(
             forecaster_name  = type(self).__name__,
@@ -1033,7 +1035,9 @@ class ForecasterAutoregMultiSeries(ForecasterBase):
                 )
 
         if last_window is None:
-            last_window = deepcopy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         check_predict_input(
             forecaster_name  = type(self).__name__,

--- a/skforecast/ForecasterAutoregMultiSeriesCustom/ForecasterAutoregMultiSeriesCustom.py
+++ b/skforecast/ForecasterAutoregMultiSeriesCustom/ForecasterAutoregMultiSeriesCustom.py
@@ -871,7 +871,9 @@ class ForecasterAutoregMultiSeriesCustom(ForecasterBase):
             levels = [levels]
 
         if last_window is None:
-            last_window = deepcopy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         last_window = last_window.iloc[-self.window_size:, ]
         
@@ -1059,7 +1061,9 @@ class ForecasterAutoregMultiSeriesCustom(ForecasterBase):
                 )
 
         if last_window is None:
-            last_window = deepcopy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
 
         last_window = last_window.iloc[-self.window_size:, ]
 

--- a/skforecast/ForecasterAutoregMultiVariate/ForecasterAutoregMultiVariate.py
+++ b/skforecast/ForecasterAutoregMultiVariate/ForecasterAutoregMultiVariate.py
@@ -912,7 +912,9 @@ class ForecasterAutoregMultiVariate(ForecasterBase):
                 )
 
         if last_window is None:
-            last_window = deepcopy(self.last_window)
+            last_window = self.last_window.copy()
+        else:
+            last_window = last_window.copy()
         
         check_predict_input(
             forecaster_name  = type(self).__name__,


### PR DESCRIPTION
**Issue:**
The `predict` method does not copy the `last_window` when `last_window` is not None.

**Proposed Changes:**
Modify the `predict` method to create a copy of `last_window` when `last_window` is not None. This ensures that the original `last_window` object remains unaltered, especially when a `transformer_y` is used in the forecaster.

**Reasoning:**
Currently, the absence of copying `last_window` may lead to unintended modifications when a `transformer_y`.

