### PR TITLE
Update ForecasterAutoreg.py

### DIFF
--- a/skforecast/ForecasterAutoreg/ForecasterAutoreg.py
+++ b/skforecast/ForecasterAutoreg/ForecasterAutoreg.py
@@ -264,7 +264,7 @@ class ForecasterAutoreg(ForecasterBase):
             self.binner_kwargs = binner_kwargs
             self.binner_kwargs['encode'] = 'ordinal'
             self.binner_kwargs['dtype'] = np.float64
-        self.binner = KBinsDiscretizer(**self.binner_kwargs)
+        self.binner = KBinsDiscretizer(**self.binner_kwargs).set_output(transform="default")
         self.binner_intervals = None
 
         if self.differentiation is not None:


### PR DESCRIPTION
Set the output container for _KBinsDiscretizer_ binner to avoid the ValueError caused by `np.concatenate`.