### PR TITLE
feat: add py.typed marker for PEP 561 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,3 +161,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "if TYPE_CHECKING:",
 ]
+
+[tool.setuptools.package-data]
+skforecast = ["py.typed"]


### PR DESCRIPTION
## Summary
Adds an empty `py.typed` marker file to the `skforecast/` package directory as specified by PEP 561.

## Problem
Type checkers (Pyright, Pylance, mypy) treat `skforecast` as untyped because there is no `py.typed` marker, causing warnings like:
`Stub file not found for "skforecast"` (reportMissingTypeStubs)

## Fix
- Add an empty `skforecast/py.typed` marker file (zero bytes, no logic changes)
- - Add `[tool.setuptools.package-data]` entry in `pyproject.toml` so the file is included in the built distribution
No logic changes, no new dependencies.