### PR TITLE
Refactor bayesian_search_forecaster to return study object; update do…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -433,7 +433,7 @@ def search_space(trial):
         'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True)
     }
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv,
@@ -445,6 +445,7 @@ results, best_trial = bayesian_search_forecaster(
     n_jobs='auto',
     show_progress=True
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models (ARIMA, ETS, ARAR)
@@ -636,8 +637,26 @@ from skforecast.plot import backtesting_gif_creator
 from skforecast.plot import set_dark_theme
 
 # Exceptions and Warnings
+from skforecast.exceptions import DataTypeWarning
+from skforecast.exceptions import DataTransformationWarning
+from skforecast.exceptions import ExogenousInterpretationWarning
+from skforecast.exceptions import FeatureOutOfRangeWarning
+from skforecast.exceptions import IgnoredArgumentWarning
+from skforecast.exceptions import InputTypeWarning
+from skforecast.exceptions import LongTrainingWarning
+from skforecast.exceptions import MissingExogWarning
+from skforecast.exceptions import MissingValuesWarning
+from skforecast.exceptions import OneStepAheadValidationWarning
+from skforecast.exceptions import ResidualsUsageWarning
+from skforecast.exceptions import SaveLoadSkforecastWarning
+from skforecast.exceptions import SkforecastVersionWarning
+from skforecast.exceptions import UnknownLevelWarning
 from skforecast.exceptions import set_warnings_style
 from skforecast.exceptions import warn_skforecast_categories
+from skforecast.exceptions import runtime_deprecated
+
+# Experimental
+from skforecast.experimental import calculate_distance_from_holiday
 ```
 
 ## Available Datasets

--- a/.github/workflows/ai-context-check.yml
+++ b/.github/workflows/ai-context-check.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           python-version: '3.12'
       - name: Check AI context files are up-to-date
-        run: python tools/ai/generate_ai_context_files.py --check
+        run: python tools/ai/generate_ai_context_files.py --check --check-urls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,7 +433,7 @@ def search_space(trial):
         'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True)
     }
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv,
@@ -445,6 +445,7 @@ results, best_trial = bayesian_search_forecaster(
     n_jobs='auto',
     show_progress=True
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models (ARIMA, ETS, ARAR)
@@ -636,8 +637,26 @@ from skforecast.plot import backtesting_gif_creator
 from skforecast.plot import set_dark_theme
 
 # Exceptions and Warnings
+from skforecast.exceptions import DataTypeWarning
+from skforecast.exceptions import DataTransformationWarning
+from skforecast.exceptions import ExogenousInterpretationWarning
+from skforecast.exceptions import FeatureOutOfRangeWarning
+from skforecast.exceptions import IgnoredArgumentWarning
+from skforecast.exceptions import InputTypeWarning
+from skforecast.exceptions import LongTrainingWarning
+from skforecast.exceptions import MissingExogWarning
+from skforecast.exceptions import MissingValuesWarning
+from skforecast.exceptions import OneStepAheadValidationWarning
+from skforecast.exceptions import ResidualsUsageWarning
+from skforecast.exceptions import SaveLoadSkforecastWarning
+from skforecast.exceptions import SkforecastVersionWarning
+from skforecast.exceptions import UnknownLevelWarning
 from skforecast.exceptions import set_warnings_style
 from skforecast.exceptions import warn_skforecast_categories
+from skforecast.exceptions import runtime_deprecated
+
+# Experimental
+from skforecast.experimental import calculate_distance_from_holiday
 ```
 
 ## Available Datasets

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -400,7 +400,7 @@ def search_space(trial):
         'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True)
     }
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv,
@@ -412,6 +412,7 @@ results, best_trial = bayesian_search_forecaster(
     n_jobs='auto',
     show_progress=True
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models (ARIMA, ETS, ARAR)
@@ -603,8 +604,26 @@ from skforecast.plot import backtesting_gif_creator
 from skforecast.plot import set_dark_theme
 
 # Exceptions and Warnings
+from skforecast.exceptions import DataTypeWarning
+from skforecast.exceptions import DataTransformationWarning
+from skforecast.exceptions import ExogenousInterpretationWarning
+from skforecast.exceptions import FeatureOutOfRangeWarning
+from skforecast.exceptions import IgnoredArgumentWarning
+from skforecast.exceptions import InputTypeWarning
+from skforecast.exceptions import LongTrainingWarning
+from skforecast.exceptions import MissingExogWarning
+from skforecast.exceptions import MissingValuesWarning
+from skforecast.exceptions import OneStepAheadValidationWarning
+from skforecast.exceptions import ResidualsUsageWarning
+from skforecast.exceptions import SaveLoadSkforecastWarning
+from skforecast.exceptions import SkforecastVersionWarning
+from skforecast.exceptions import UnknownLevelWarning
 from skforecast.exceptions import set_warnings_style
 from skforecast.exceptions import warn_skforecast_categories
+from skforecast.exceptions import runtime_deprecated
+
+# Experimental
+from skforecast.experimental import calculate_distance_from_holiday
 ```
 
 ## Available Datasets
@@ -1380,7 +1399,7 @@ def search_space(trial):
     }
 
 # n_trials=20 is the default. Increase for better results (50-200 recommended).
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     exog=exog,
@@ -1395,6 +1414,7 @@ results, best_trial = bayesian_search_forecaster(
     output_file='search_results.csv',  # Save results incrementally
 )
 # results is a DataFrame sorted by metric (best first)
+# study is the full Optuna Study; access the best trial with study.best_trial
 ```
 
 ## Grid Search
@@ -1471,7 +1491,7 @@ cv = TimeSeriesFold(
     refit=False,
 )
 
-results, best_trial = bayesian_search_forecaster_multiseries(
+results, study = bayesian_search_forecaster_multiseries(
     forecaster=forecaster,
     series=series,
     exog=exog,
@@ -1485,6 +1505,7 @@ results, best_trial = bayesian_search_forecaster_multiseries(
     n_jobs='auto',
     show_progress=True,
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models Search
@@ -1522,7 +1543,7 @@ cv_fast = OneStepAheadFold(
     initial_train_size=len(data) - 100,
 )
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv_fast,
@@ -1531,6 +1552,7 @@ results, best_trial = bayesian_search_forecaster(
     n_trials=100,
     return_best=True,
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Common Mistakes
@@ -1713,7 +1735,7 @@ param_grid = {
 
 ```python
 # Advanced: customize Optuna study
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     ...,
     kwargs_create_study={
         'sampler': optuna.samplers.TPESampler(seed=123),
@@ -1724,20 +1746,21 @@ results, best_trial = bayesian_search_forecaster(
         'gc_after_trial': True,
     },
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Return Values
 
-| Function | Returns | Best trial object |
+| Function | Returns | Study object |
 |----------|---------|:-:|
 | `grid_search_*` | `pd.DataFrame` sorted by metric | — |
 | `random_search_*` | `pd.DataFrame` sorted by metric | — |
-| `bayesian_search_*` | `tuple[pd.DataFrame, optuna.FrozenTrial]` | ✓ |
+| `bayesian_search_*` | `tuple[pd.DataFrame, optuna Study]` | ✓ |
 | `*_stats` | `pd.DataFrame` sorted by metric | — |
 
 When `return_best=True`, the forecaster is automatically updated with the
 best parameters found. The results DataFrame always has rows sorted by
-metric (best first).
+metric (best first). Access the best Optuna trial with `study.best_trial`.
 
 ================================================================================
 # SKILL: prediction-intervals
@@ -2146,6 +2169,13 @@ sunlight features, differencing, or data scaling.
 
 
 ## Calendar Features with feature_engine
+
+`feature-engine` is not a core skforecast dependency. Install it separately
+before using `DatetimeFeatures` or `CyclicalFeatures`:
+
+```bash
+pip install feature-engine
+```
 
 ### Manual extraction (pandas)
 
@@ -3859,36 +3889,40 @@ predictions = forecaster.predict(steps=10, exog=exog_test)
 ```python
 # ❌ WRONG: using backtesting_forecaster with ForecasterStats
 from skforecast.model_selection import backtesting_forecaster
-backtesting_forecaster(forecaster=forecaster_stats, ...)  # Error!
+backtesting_forecaster(forecaster=forecaster_stats, y=y, cv=cv, metric=metric)  # Error!
 
 # ✅ CORRECT: use backtesting_stats for statistical models
 from skforecast.model_selection import backtesting_stats
-backtesting_stats(forecaster=forecaster_stats, ...)
+backtesting_stats(forecaster=forecaster_stats, y=y, cv=cv, metric=metric)
 
 # ❌ WRONG: using backtesting_forecaster with ForecasterRecursiveMultiSeries
-backtesting_forecaster(forecaster=forecaster_multi, ...)  # Error!
+backtesting_forecaster(forecaster=forecaster_multi, y=y, cv=cv, metric=metric)  # Error!
 
 # ✅ CORRECT: use backtesting_forecaster_multiseries
 from skforecast.model_selection import backtesting_forecaster_multiseries
-backtesting_forecaster_multiseries(forecaster=forecaster_multi, series=series, ...)
+backtesting_forecaster_multiseries(
+    forecaster=forecaster_multi, series=series, cv=cv, metric=metric
+)
 ```
 
 ## Wrong Search Function
 
 ```python
 # ❌ WRONG: grid_search_forecaster with ForecasterStats
-grid_search_forecaster(forecaster=forecaster_stats, ...)
+grid_search_forecaster(forecaster=forecaster_stats, y=y, cv=cv, param_grid=param_grid)
 
 # ✅ CORRECT: grid_search_stats for statistical models
 from skforecast.model_selection import grid_search_stats
-grid_search_stats(forecaster=forecaster_stats, ...)
+grid_search_stats(forecaster=forecaster_stats, y=y, cv=cv, param_grid=param_grid)
 
 # ❌ WRONG: grid_search_forecaster with ForecasterRecursiveMultiSeries
-grid_search_forecaster(forecaster=forecaster_multi, ...)
+grid_search_forecaster(forecaster=forecaster_multi, y=y, cv=cv, param_grid=param_grid)
 
 # ✅ CORRECT: grid_search_forecaster_multiseries
 from skforecast.model_selection import grid_search_forecaster_multiseries
-grid_search_forecaster_multiseries(forecaster=forecaster_multi, series=series, ...)
+grid_search_forecaster_multiseries(
+    forecaster=forecaster_multi, series=series, cv=cv, param_grid=param_grid
+)
 ```
 
 ## Prediction Interval Errors

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,15 +12,15 @@ Skforecast supports recursive and direct multi-step forecasting strategies, glob
 
 ## Core Forecasters
 
-- [ForecasterRecursive](https://skforecast.org/latest/api/ForecasterRecursive.html): Single series, recursive multi-step forecasting using autoregressive lags
-- [ForecasterDirect](https://skforecast.org/latest/api/ForecasterDirect.html): Single series, direct multi-step forecasting with one model per step
-- [ForecasterRecursiveMultiSeries](https://skforecast.org/latest/api/ForecasterRecursiveMultiSeries.html): Multiple series forecasting with a single global model
-- [ForecasterDirectMultiVariate](https://skforecast.org/latest/api/ForecasterDirectMultiVariate.html): Multivariate forecasting using multiple series as input features
-- [ForecasterRnn](https://skforecast.org/latest/api/ForecasterRnn.html): Deep learning forecasting with RNN/LSTM architectures
-- [ForecasterStats](https://skforecast.org/latest/api/ForecasterStats.html): Statistical models (ARIMA, SARIMAX, ETS, ARAR) with sklearn-compatible interface
-- [ForecasterFoundation](https://skforecast.org/latest/api/ForecasterFoundation.html): Zero-shot forecasting with pre-trained foundation models (Chronos-2, TimesFM 2.5, Moirai-2, TabICL)
-- [ForecasterRecursiveClassifier](https://skforecast.org/latest/api/ForecasterRecursiveClassifier.html): Classification-based forecasting for categorical time series
-- [ForecasterEquivalentDate](https://skforecast.org/latest/api/ForecasterEquivalentDate.html): Baseline forecaster using equivalent past dates
+- [ForecasterRecursive](https://skforecast.org/latest/api/forecasterrecursive): Single series, recursive multi-step forecasting using autoregressive lags
+- [ForecasterDirect](https://skforecast.org/latest/api/forecasterdirect): Single series, direct multi-step forecasting with one model per step
+- [ForecasterRecursiveMultiSeries](https://skforecast.org/latest/api/forecasterrecursivemultiseries): Multiple series forecasting with a single global model
+- [ForecasterDirectMultiVariate](https://skforecast.org/latest/api/forecasterdirectmultivariate): Multivariate forecasting using multiple series as input features
+- [ForecasterRnn](https://skforecast.org/latest/api/forecasterrnn): Deep learning forecasting with RNN/LSTM architectures
+- [ForecasterStats](https://skforecast.org/latest/api/forecasterstats): Statistical models (ARIMA, SARIMAX, ETS, ARAR) with sklearn-compatible interface
+- [ForecasterFoundation](https://skforecast.org/latest/api/forecasterfoundation): Zero-shot forecasting with pre-trained foundation models (Chronos-2, TimesFM 2.5, Moirai-2, TabICL)
+- [ForecasterRecursiveClassifier](https://skforecast.org/latest/api/forecasterrecursiveclassifier): Classification-based forecasting for categorical time series
+- [ForecasterEquivalentDate](https://skforecast.org/latest/api/forecasterequivalentdate): Baseline forecaster using equivalent past dates
 
 ## User Guides
 
@@ -90,7 +90,8 @@ Skforecast supports recursive and direct multi-step forecasting strategies, glob
 - [preprocessing](https://skforecast.org/latest/api/preprocessing.html): RollingFeatures, TimeSeriesDifferentiator, DateTimeFeatureTransformer, QuantileBinner
 - [feature_selection](https://skforecast.org/latest/api/feature_selection.html): select_features, select_features_multiseries
 - [stats](https://skforecast.org/latest/api/stats.html): Arima, Sarimax, Ets, Arar model classes
-- [foundation](https://skforecast.org/latest/api/foundation.html): FoundationModel, ForecasterFoundation, Chronos-2 / TimesFM 2.5 / Moirai-2 / TabICL adapters
+- [FoundationModel](https://skforecast.org/latest/api/foundationmodel): Estimator used by ForecasterFoundation to run zero-shot foundation models; delegates model-specific execution to low-level adapters for Chronos-2 / TimesFM 2.5 / Moirai-2 / TabICL
+- [ForecasterFoundation](https://skforecast.org/latest/api/forecasterfoundation): High-level zero-shot forecaster integrated with skforecast backtesting and prediction intervals
 - [drift_detection](https://skforecast.org/latest/api/drift_detection.html): RangeDriftDetector, PopulationDriftDetector
 - [metrics](https://skforecast.org/latest/api/metrics.html): MASE, RMSSE, sMAPE, CRPS, pinball loss, coverage
 - [datasets](https://skforecast.org/latest/api/datasets.html): fetch_dataset, load_demo_dataset with 30+ built-in datasets
@@ -104,7 +105,7 @@ Skforecast supports recursive and direct multi-step forecasting strategies, glob
 - [Weighted forecasting](https://skforecast.org/latest/user_guides/weighted-time-series-forecasting.html): Assigning weights to recent vs older observations
 - [Stacking ensemble](https://skforecast.org/latest/user_guides/stacking-ensemble-models-forecasting.html): Combining multiple models with stacking
 - [XGBoost and LightGBM](https://skforecast.org/latest/user_guides/forecasting-xgboost-lightgbm.html): Specific tips for gradient boosting frameworks
-- [GPU usage](https://skforecast.org/latest/user_guides/skforecast-in-GPU.html): Running skforecast on GPU with RAPIDS and CUDA
+- [GPU usage](https://skforecast.org/latest/user_guides/skforecast-in-gpu): Running skforecast on GPU with RAPIDS and CUDA
 - [Plotting](https://skforecast.org/latest/user_guides/plotting.html): Visualization functions for time series and forecasts
 - [Datasets catalog](https://skforecast.org/latest/user_guides/datasets.html): 30+ built-in datasets with descriptions and frequencies
 - [Training matrices](https://skforecast.org/latest/user_guides/training-and-prediction-matrices.html): Inspecting the internal feature matrices used by forecasters

--- a/docs/quick-start/ai-assisted-forecasting.md
+++ b/docs/quick-start/ai-assisted-forecasting.md
@@ -3,31 +3,33 @@
 Skforecast provides machine-readable context files so that AI coding assistants (ChatGPT, Claude, Gemini, GitHub Copilot, Cursor, and others) can generate **accurate, up-to-date code** for time series forecasting.
 
 
-## Quick start: paste a URL into any LLM
+## Quick start: provide the context to an LLM
 
-Copy the following URL and paste it into any AI chat:
+If your AI assistant can access web pages, paste the following URL into the chat:
 
 ```
 https://skforecast.org/latest/llms-full.txt
 ```
 
-This single file contains the complete API reference, all forecaster signatures, workflow examples, and best practices. It gives any LLM enough context to help you with skforecast without hallucinating deprecated methods or wrong parameter names.
+If your assistant cannot browse URLs, open the file and paste or upload its contents instead.
+
+This single file contains the core API reference, forecaster APIs, workflow examples, and best practices. It gives AI assistants enough context to help you with skforecast while reducing hallucinations about deprecated methods or wrong parameter names.
 
 **Example prompt:**
 
 > Using the context from https://skforecast.org/latest/llms-full.txt, create a ForecasterRecursiveMultiSeries with LightGBM, fit it on a DataFrame with 3 series, and run backtesting with conformal prediction intervals.
 
 
-## IDE integration (automatic)
+## IDE integration
 
-If you clone or open the skforecast repository in an AI-enabled IDE, the context is loaded **automatically**, no manual setup required:
+If you clone or open the skforecast repository in an AI-enabled IDE that supports repository context files, the assistant can load the relevant context from the repo:
 
 | IDE / Tool | File loaded | How |
 |------------|-------------|-----|
-| **VS Code + GitHub Copilot** | `.github/copilot-instructions.md` | Injected into every Copilot prompt |
-| **Claude Code** | `AGENTS.md` | Read automatically at project root |
-| **OpenAI Codex / Aider** | `AGENTS.md` | Read automatically at project root |
-| **Cursor** | `AGENTS.md` | Read automatically at project root |
+| **VS Code + GitHub Copilot** | `.github/copilot-instructions.md` | Used as repository instructions by Copilot |
+| **Claude Code** | `AGENTS.md` | Read from the project root |
+| **OpenAI Codex / Aider** | `AGENTS.md` | Read when the tool supports the AGENTS.md convention |
+| **Cursor** | `AGENTS.md` | Can be used as project context when supported or configured |
 
 These files contain the same core content: project structure, all forecasters, code style, and testing conventions.
 
@@ -41,8 +43,8 @@ The AI context covers:
 - **Model selection** — `backtesting_forecaster`, `bayesian_search_forecaster` and other hyperparameter optimization methods, `TimeSeriesFold`, `OneStepAheadFold`, and their multi-series variants.
 - **Statistical models** — `Arima`, `Sarimax`, `Ets`, `Arar` wrapped by `ForecasterStats`.
 - **Deep learning** — `ForecasterRnn` with `create_and_compile_model`, LSTM/GRU architectures.
-- **Foundation models (zero-shot)** — `FoundationModel` + `ForecasterFoundation` with Chronos-2, TimesFM 2.5, and Moirai-2 backends.
-- **Feature engineering** — `RollingFeatures`, custom features, and exogenous variables.
+- **Foundation models (zero-shot)** — `FoundationModel` + `ForecasterFoundation` with Chronos-2, TimesFM 2.5, Moirai-2, and TabICL backends.
+- **Feature engineering** — `RollingFeatures`, feature_engine calendar/cyclical features, custom features, and exogenous variables.
 - **Feature selection** — `RFECV`, `SelectFromModel` for lags, window features, and exogenous variables.
 - **Drift detection** — `RangeDriftDetector` and `PopulationDriftDetector` for production monitoring.
 - **13 specialized workflow skills** — step-by-step guides for common tasks, loaded on-demand by advanced AI agents.
@@ -59,11 +61,11 @@ Skforecast includes 13 modular **skills** — self-contained guides that AI agen
 | `statistical-models` | `ForecasterStats` with `Arima`, `Sarimax`, `Ets`, `Arar`: auto-ARIMA, seasonal config |
 | `hyperparameter-optimization` | Grid, random, and Bayesian search with `TimeSeriesFold` and `OneStepAheadFold` |
 | `prediction-intervals` | Bootstrapping, conformal prediction, quantile regression, interval calibration |
-| `feature-engineering` | `RollingFeatures`, `DateTimeFeatureTransformer`, custom features, exogenous variables |
+| `feature-engineering` | `RollingFeatures`, feature_engine calendar/cyclical features, custom features, exogenous variables |
 | `feature-selection` | `RFECV`, `SelectFromModel`: selecting lags, window features, and exog |
 | `drift-detection` | `RangeDriftDetector` and `PopulationDriftDetector` for production monitoring |
 | `deep-learning-forecasting` | `ForecasterRnn` with Keras: `create_and_compile_model`, LSTM/GRU architectures |
-| `foundation-forecasting` | Zero-shot forecasting with `ForecasterFoundation`: Chronos-2, TimesFM 2.5, Moirai-2 |
+| `foundation-forecasting` | Zero-shot forecasting with `ForecasterFoundation`: Chronos-2, TimesFM 2.5, Moirai-2, TabICL |
 | `choosing-a-forecaster` | Decision guide: "I have X situation → use Y forecaster" |
 | `troubleshooting-common-errors` | Frequent mistakes AI assistants make with skforecast and their corrections |
 | `complete-api-reference` | Full method signatures and availability matrix for all forecasters |
@@ -80,7 +82,7 @@ These skills are bundled into `llms-full.txt`. AI agents that support the [Agent
 | `.github/copilot-instructions.md` | Contributors (VS Code) | Auto-injected into GitHub Copilot |
 | `AGENTS.md` | Contributors (Claude Code, Codex, Aider) | Standard agent context file |
 
-The context files are **auto-generated** from a single source of truth (`tools/ai/llms-base.txt`) to ensure they stay in sync with the library. They are regenerated on every release.
+The context files are **auto-generated** from maintained source files (`tools/ai/llms-base.txt`, `llms.txt`, `tools/ai/ai_context_header.md`, and `skills/`) to ensure they stay in sync with the library. They are regenerated on every release.
 
 
 ## Tips for better results
@@ -88,4 +90,4 @@ The context files are **auto-generated** from a single source of truth (`tools/a
 1. **Always provide the context URL** — Without it, LLMs may hallucinate methods that don't exist or use outdated API names (e.g., `ForecasterAutoreg` instead of `ForecasterRecursive`).
 2. **Be specific about your forecaster** — Mention which forecaster you're using. Parameter names and defaults differ across forecasters.
 3. **Mention the version** — Say "skforecast 0.22.0" so the LLM doesn't mix advice from older versions.
-4. **Validate the output** — AI-generated code is a starting point. Always run backtesting to verify model performance.
+4. **Validate the output** — AI-generated code is a starting point. Use backtesting or an appropriate holdout evaluation to verify model performance.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -400,7 +400,7 @@ def search_space(trial):
         'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True)
     }
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv,
@@ -412,6 +412,7 @@ results, best_trial = bayesian_search_forecaster(
     n_jobs='auto',
     show_progress=True
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models (ARIMA, ETS, ARAR)
@@ -603,8 +604,26 @@ from skforecast.plot import backtesting_gif_creator
 from skforecast.plot import set_dark_theme
 
 # Exceptions and Warnings
+from skforecast.exceptions import DataTypeWarning
+from skforecast.exceptions import DataTransformationWarning
+from skforecast.exceptions import ExogenousInterpretationWarning
+from skforecast.exceptions import FeatureOutOfRangeWarning
+from skforecast.exceptions import IgnoredArgumentWarning
+from skforecast.exceptions import InputTypeWarning
+from skforecast.exceptions import LongTrainingWarning
+from skforecast.exceptions import MissingExogWarning
+from skforecast.exceptions import MissingValuesWarning
+from skforecast.exceptions import OneStepAheadValidationWarning
+from skforecast.exceptions import ResidualsUsageWarning
+from skforecast.exceptions import SaveLoadSkforecastWarning
+from skforecast.exceptions import SkforecastVersionWarning
+from skforecast.exceptions import UnknownLevelWarning
 from skforecast.exceptions import set_warnings_style
 from skforecast.exceptions import warn_skforecast_categories
+from skforecast.exceptions import runtime_deprecated
+
+# Experimental
+from skforecast.experimental import calculate_distance_from_holiday
 ```
 
 ## Available Datasets
@@ -1380,7 +1399,7 @@ def search_space(trial):
     }
 
 # n_trials=20 is the default. Increase for better results (50-200 recommended).
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     exog=exog,
@@ -1395,6 +1414,7 @@ results, best_trial = bayesian_search_forecaster(
     output_file='search_results.csv',  # Save results incrementally
 )
 # results is a DataFrame sorted by metric (best first)
+# study is the full Optuna Study; access the best trial with study.best_trial
 ```
 
 ## Grid Search
@@ -1471,7 +1491,7 @@ cv = TimeSeriesFold(
     refit=False,
 )
 
-results, best_trial = bayesian_search_forecaster_multiseries(
+results, study = bayesian_search_forecaster_multiseries(
     forecaster=forecaster,
     series=series,
     exog=exog,
@@ -1485,6 +1505,7 @@ results, best_trial = bayesian_search_forecaster_multiseries(
     n_jobs='auto',
     show_progress=True,
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models Search
@@ -1522,7 +1543,7 @@ cv_fast = OneStepAheadFold(
     initial_train_size=len(data) - 100,
 )
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv_fast,
@@ -1531,6 +1552,7 @@ results, best_trial = bayesian_search_forecaster(
     n_trials=100,
     return_best=True,
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Common Mistakes
@@ -1713,7 +1735,7 @@ param_grid = {
 
 ```python
 # Advanced: customize Optuna study
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     ...,
     kwargs_create_study={
         'sampler': optuna.samplers.TPESampler(seed=123),
@@ -1724,20 +1746,21 @@ results, best_trial = bayesian_search_forecaster(
         'gc_after_trial': True,
     },
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Return Values
 
-| Function | Returns | Best trial object |
+| Function | Returns | Study object |
 |----------|---------|:-:|
 | `grid_search_*` | `pd.DataFrame` sorted by metric | — |
 | `random_search_*` | `pd.DataFrame` sorted by metric | — |
-| `bayesian_search_*` | `tuple[pd.DataFrame, optuna.FrozenTrial]` | ✓ |
+| `bayesian_search_*` | `tuple[pd.DataFrame, optuna Study]` | ✓ |
 | `*_stats` | `pd.DataFrame` sorted by metric | — |
 
 When `return_best=True`, the forecaster is automatically updated with the
 best parameters found. The results DataFrame always has rows sorted by
-metric (best first).
+metric (best first). Access the best Optuna trial with `study.best_trial`.
 
 ================================================================================
 # SKILL: prediction-intervals
@@ -2146,6 +2169,13 @@ sunlight features, differencing, or data scaling.
 
 
 ## Calendar Features with feature_engine
+
+`feature-engine` is not a core skforecast dependency. Install it separately
+before using `DatetimeFeatures` or `CyclicalFeatures`:
+
+```bash
+pip install feature-engine
+```
 
 ### Manual extraction (pandas)
 
@@ -3859,36 +3889,40 @@ predictions = forecaster.predict(steps=10, exog=exog_test)
 ```python
 # ❌ WRONG: using backtesting_forecaster with ForecasterStats
 from skforecast.model_selection import backtesting_forecaster
-backtesting_forecaster(forecaster=forecaster_stats, ...)  # Error!
+backtesting_forecaster(forecaster=forecaster_stats, y=y, cv=cv, metric=metric)  # Error!
 
 # ✅ CORRECT: use backtesting_stats for statistical models
 from skforecast.model_selection import backtesting_stats
-backtesting_stats(forecaster=forecaster_stats, ...)
+backtesting_stats(forecaster=forecaster_stats, y=y, cv=cv, metric=metric)
 
 # ❌ WRONG: using backtesting_forecaster with ForecasterRecursiveMultiSeries
-backtesting_forecaster(forecaster=forecaster_multi, ...)  # Error!
+backtesting_forecaster(forecaster=forecaster_multi, y=y, cv=cv, metric=metric)  # Error!
 
 # ✅ CORRECT: use backtesting_forecaster_multiseries
 from skforecast.model_selection import backtesting_forecaster_multiseries
-backtesting_forecaster_multiseries(forecaster=forecaster_multi, series=series, ...)
+backtesting_forecaster_multiseries(
+    forecaster=forecaster_multi, series=series, cv=cv, metric=metric
+)
 ```
 
 ## Wrong Search Function
 
 ```python
 # ❌ WRONG: grid_search_forecaster with ForecasterStats
-grid_search_forecaster(forecaster=forecaster_stats, ...)
+grid_search_forecaster(forecaster=forecaster_stats, y=y, cv=cv, param_grid=param_grid)
 
 # ✅ CORRECT: grid_search_stats for statistical models
 from skforecast.model_selection import grid_search_stats
-grid_search_stats(forecaster=forecaster_stats, ...)
+grid_search_stats(forecaster=forecaster_stats, y=y, cv=cv, param_grid=param_grid)
 
 # ❌ WRONG: grid_search_forecaster with ForecasterRecursiveMultiSeries
-grid_search_forecaster(forecaster=forecaster_multi, ...)
+grid_search_forecaster(forecaster=forecaster_multi, y=y, cv=cv, param_grid=param_grid)
 
 # ✅ CORRECT: grid_search_forecaster_multiseries
 from skforecast.model_selection import grid_search_forecaster_multiseries
-grid_search_forecaster_multiseries(forecaster=forecaster_multi, series=series, ...)
+grid_search_forecaster_multiseries(
+    forecaster=forecaster_multi, series=series, cv=cv, param_grid=param_grid
+)
 ```
 
 ## Prediction Interval Errors

--- a/llms.txt
+++ b/llms.txt
@@ -12,15 +12,15 @@ Skforecast supports recursive and direct multi-step forecasting strategies, glob
 
 ## Core Forecasters
 
-- [ForecasterRecursive](https://skforecast.org/latest/api/ForecasterRecursive.html): Single series, recursive multi-step forecasting using autoregressive lags
-- [ForecasterDirect](https://skforecast.org/latest/api/ForecasterDirect.html): Single series, direct multi-step forecasting with one model per step
-- [ForecasterRecursiveMultiSeries](https://skforecast.org/latest/api/ForecasterRecursiveMultiSeries.html): Multiple series forecasting with a single global model
-- [ForecasterDirectMultiVariate](https://skforecast.org/latest/api/ForecasterDirectMultiVariate.html): Multivariate forecasting using multiple series as input features
-- [ForecasterRnn](https://skforecast.org/latest/api/ForecasterRnn.html): Deep learning forecasting with RNN/LSTM architectures
-- [ForecasterStats](https://skforecast.org/latest/api/ForecasterStats.html): Statistical models (ARIMA, SARIMAX, ETS, ARAR) with sklearn-compatible interface
-- [ForecasterFoundation](https://skforecast.org/latest/api/ForecasterFoundation.html): Zero-shot forecasting with pre-trained foundation models (Chronos-2, TimesFM 2.5, Moirai-2, TabICL)
-- [ForecasterRecursiveClassifier](https://skforecast.org/latest/api/ForecasterRecursiveClassifier.html): Classification-based forecasting for categorical time series
-- [ForecasterEquivalentDate](https://skforecast.org/latest/api/ForecasterEquivalentDate.html): Baseline forecaster using equivalent past dates
+- [ForecasterRecursive](https://skforecast.org/latest/api/forecasterrecursive): Single series, recursive multi-step forecasting using autoregressive lags
+- [ForecasterDirect](https://skforecast.org/latest/api/forecasterdirect): Single series, direct multi-step forecasting with one model per step
+- [ForecasterRecursiveMultiSeries](https://skforecast.org/latest/api/forecasterrecursivemultiseries): Multiple series forecasting with a single global model
+- [ForecasterDirectMultiVariate](https://skforecast.org/latest/api/forecasterdirectmultivariate): Multivariate forecasting using multiple series as input features
+- [ForecasterRnn](https://skforecast.org/latest/api/forecasterrnn): Deep learning forecasting with RNN/LSTM architectures
+- [ForecasterStats](https://skforecast.org/latest/api/forecasterstats): Statistical models (ARIMA, SARIMAX, ETS, ARAR) with sklearn-compatible interface
+- [ForecasterFoundation](https://skforecast.org/latest/api/forecasterfoundation): Zero-shot forecasting with pre-trained foundation models (Chronos-2, TimesFM 2.5, Moirai-2, TabICL)
+- [ForecasterRecursiveClassifier](https://skforecast.org/latest/api/forecasterrecursiveclassifier): Classification-based forecasting for categorical time series
+- [ForecasterEquivalentDate](https://skforecast.org/latest/api/forecasterequivalentdate): Baseline forecaster using equivalent past dates
 
 ## User Guides
 
@@ -90,7 +90,8 @@ Skforecast supports recursive and direct multi-step forecasting strategies, glob
 - [preprocessing](https://skforecast.org/latest/api/preprocessing.html): RollingFeatures, TimeSeriesDifferentiator, DateTimeFeatureTransformer, QuantileBinner
 - [feature_selection](https://skforecast.org/latest/api/feature_selection.html): select_features, select_features_multiseries
 - [stats](https://skforecast.org/latest/api/stats.html): Arima, Sarimax, Ets, Arar model classes
-- [foundation](https://skforecast.org/latest/api/foundation.html): FoundationModel, ForecasterFoundation, Chronos-2 / TimesFM 2.5 / Moirai-2 / TabICL adapters
+- [FoundationModel](https://skforecast.org/latest/api/foundationmodel): Estimator used by ForecasterFoundation to run zero-shot foundation models; delegates model-specific execution to low-level adapters for Chronos-2 / TimesFM 2.5 / Moirai-2 / TabICL
+- [ForecasterFoundation](https://skforecast.org/latest/api/forecasterfoundation): High-level zero-shot forecaster integrated with skforecast backtesting and prediction intervals
 - [drift_detection](https://skforecast.org/latest/api/drift_detection.html): RangeDriftDetector, PopulationDriftDetector
 - [metrics](https://skforecast.org/latest/api/metrics.html): MASE, RMSSE, sMAPE, CRPS, pinball loss, coverage
 - [datasets](https://skforecast.org/latest/api/datasets.html): fetch_dataset, load_demo_dataset with 30+ built-in datasets
@@ -104,7 +105,7 @@ Skforecast supports recursive and direct multi-step forecasting strategies, glob
 - [Weighted forecasting](https://skforecast.org/latest/user_guides/weighted-time-series-forecasting.html): Assigning weights to recent vs older observations
 - [Stacking ensemble](https://skforecast.org/latest/user_guides/stacking-ensemble-models-forecasting.html): Combining multiple models with stacking
 - [XGBoost and LightGBM](https://skforecast.org/latest/user_guides/forecasting-xgboost-lightgbm.html): Specific tips for gradient boosting frameworks
-- [GPU usage](https://skforecast.org/latest/user_guides/skforecast-in-GPU.html): Running skforecast on GPU with RAPIDS and CUDA
+- [GPU usage](https://skforecast.org/latest/user_guides/skforecast-in-gpu): Running skforecast on GPU with RAPIDS and CUDA
 - [Plotting](https://skforecast.org/latest/user_guides/plotting.html): Visualization functions for time series and forecasts
 - [Datasets catalog](https://skforecast.org/latest/user_guides/datasets.html): 30+ built-in datasets with descriptions and frequencies
 - [Training matrices](https://skforecast.org/latest/user_guides/training-and-prediction-matrices.html): Inspecting the internal feature matrices used by forecasters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ Homepage = "https://www.skforecast.org"
 Repository = "https://github.com/skforecast/skforecast"
 Documentation = "https://www.skforecast.org"
 "Release Notes" = "https://skforecast.org/latest/releases/releases"
-"LLM Context" = "https://skforecast.org/llms.txt"
+"LLM Context" = "https://skforecast.org/latest/llms.txt"
 Download = "https://pypi.org/project/skforecast/#files"
 Tracker = "https://github.com/skforecast/skforecast/issues"
 

--- a/skills/feature-engineering/SKILL.md
+++ b/skills/feature-engineering/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: feature-engineering
 description: >
-  Creates features for time series forecasting: calendar features with
-  feature_engine (DatetimeFeatures, CyclicalFeatures), rolling statistics
-  with RollingFeatures, differencing, and categorical exogenous variables.
-  Use when the user wants to improve model accuracy through feature
-  engineering or asks about exogenous variable creation.
+    Creates features for time series forecasting: calendar features with
+    feature_engine (DatetimeFeatures, CyclicalFeatures), rolling statistics
+    with RollingFeatures, differencing, and categorical exogenous variables.
+    Use when the user wants to improve model accuracy through feature
+    engineering or asks about exogenous variable creation.
 ---
 
 # Feature Engineering
@@ -33,6 +33,13 @@ sunlight features, differencing, or data scaling.
 
 
 ## Calendar Features with feature_engine
+
+`feature-engine` is not a core skforecast dependency. Install it separately
+before using `DatetimeFeatures` or `CyclicalFeatures`:
+
+```bash
+pip install feature-engine
+```
 
 ### Manual extraction (pandas)
 

--- a/skills/hyperparameter-optimization/SKILL.md
+++ b/skills/hyperparameter-optimization/SKILL.md
@@ -57,7 +57,7 @@ def search_space(trial):
     }
 
 # n_trials=20 is the default. Increase for better results (50-200 recommended).
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     exog=exog,
@@ -72,6 +72,7 @@ results, best_trial = bayesian_search_forecaster(
     output_file='search_results.csv',  # Save results incrementally
 )
 # results is a DataFrame sorted by metric (best first)
+# study is the full Optuna Study; access the best trial with study.best_trial
 ```
 
 ## Grid Search
@@ -148,7 +149,7 @@ cv = TimeSeriesFold(
     refit=False,
 )
 
-results, best_trial = bayesian_search_forecaster_multiseries(
+results, study = bayesian_search_forecaster_multiseries(
     forecaster=forecaster,
     series=series,
     exog=exog,
@@ -162,6 +163,7 @@ results, best_trial = bayesian_search_forecaster_multiseries(
     n_jobs='auto',
     show_progress=True,
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models Search
@@ -199,7 +201,7 @@ cv_fast = OneStepAheadFold(
     initial_train_size=len(data) - 100,
 )
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv_fast,
@@ -208,6 +210,7 @@ results, best_trial = bayesian_search_forecaster(
     n_trials=100,
     return_best=True,
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Common Mistakes

--- a/skills/hyperparameter-optimization/references/search-parameters.md
+++ b/skills/hyperparameter-optimization/references/search-parameters.md
@@ -168,7 +168,7 @@ param_grid = {
 
 ```python
 # Advanced: customize Optuna study
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     ...,
     kwargs_create_study={
         'sampler': optuna.samplers.TPESampler(seed=123),
@@ -179,17 +179,18 @@ results, best_trial = bayesian_search_forecaster(
         'gc_after_trial': True,
     },
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Return Values
 
-| Function | Returns | Best trial object |
+| Function | Returns | Study object |
 |----------|---------|:-:|
 | `grid_search_*` | `pd.DataFrame` sorted by metric | — |
 | `random_search_*` | `pd.DataFrame` sorted by metric | — |
-| `bayesian_search_*` | `tuple[pd.DataFrame, optuna.FrozenTrial]` | ✓ |
+| `bayesian_search_*` | `tuple[pd.DataFrame, optuna Study]` | ✓ |
 | `*_stats` | `pd.DataFrame` sorted by metric | — |
 
 When `return_best=True`, the forecaster is automatically updated with the
 best parameters found. The results DataFrame always has rows sorted by
-metric (best first).
+metric (best first). Access the best Optuna trial with `study.best_trial`.

--- a/skills/troubleshooting-common-errors/SKILL.md
+++ b/skills/troubleshooting-common-errors/SKILL.md
@@ -104,36 +104,40 @@ predictions = forecaster.predict(steps=10, exog=exog_test)
 ```python
 # ❌ WRONG: using backtesting_forecaster with ForecasterStats
 from skforecast.model_selection import backtesting_forecaster
-backtesting_forecaster(forecaster=forecaster_stats, ...)  # Error!
+backtesting_forecaster(forecaster=forecaster_stats, y=y, cv=cv, metric=metric)  # Error!
 
 # ✅ CORRECT: use backtesting_stats for statistical models
 from skforecast.model_selection import backtesting_stats
-backtesting_stats(forecaster=forecaster_stats, ...)
+backtesting_stats(forecaster=forecaster_stats, y=y, cv=cv, metric=metric)
 
 # ❌ WRONG: using backtesting_forecaster with ForecasterRecursiveMultiSeries
-backtesting_forecaster(forecaster=forecaster_multi, ...)  # Error!
+backtesting_forecaster(forecaster=forecaster_multi, y=y, cv=cv, metric=metric)  # Error!
 
 # ✅ CORRECT: use backtesting_forecaster_multiseries
 from skforecast.model_selection import backtesting_forecaster_multiseries
-backtesting_forecaster_multiseries(forecaster=forecaster_multi, series=series, ...)
+backtesting_forecaster_multiseries(
+    forecaster=forecaster_multi, series=series, cv=cv, metric=metric
+)
 ```
 
 ## Wrong Search Function
 
 ```python
 # ❌ WRONG: grid_search_forecaster with ForecasterStats
-grid_search_forecaster(forecaster=forecaster_stats, ...)
+grid_search_forecaster(forecaster=forecaster_stats, y=y, cv=cv, param_grid=param_grid)
 
 # ✅ CORRECT: grid_search_stats for statistical models
 from skforecast.model_selection import grid_search_stats
-grid_search_stats(forecaster=forecaster_stats, ...)
+grid_search_stats(forecaster=forecaster_stats, y=y, cv=cv, param_grid=param_grid)
 
 # ❌ WRONG: grid_search_forecaster with ForecasterRecursiveMultiSeries
-grid_search_forecaster(forecaster=forecaster_multi, ...)
+grid_search_forecaster(forecaster=forecaster_multi, y=y, cv=cv, param_grid=param_grid)
 
 # ✅ CORRECT: grid_search_forecaster_multiseries
 from skforecast.model_selection import grid_search_forecaster_multiseries
-grid_search_forecaster_multiseries(forecaster=forecaster_multi, series=series, ...)
+grid_search_forecaster_multiseries(
+    forecaster=forecaster_multi, series=series, cv=cv, param_grid=param_grid
+)
 ```
 
 ## Prediction Interval Errors

--- a/tools/ai/README.md
+++ b/tools/ai/README.md
@@ -12,7 +12,7 @@ VS Code + GitHub Copilot recognises several file conventions. Each serves a diff
 | **instructions** | `.github/instructions/*.instructions.md` | Targeted coding conventions that activate **only when the open file matches** an `applyTo` glob in the YAML frontmatter (e.g. docstring rules for `*.py`, testing rules for `tests/`). | Keep the global context lean by extracting domain-specific rules into separate files that load only when relevant, avoiding prompt bloat while ensuring precision in specialized tasks. |
 | **prompts** | `.github/prompts/*.prompt.md` | Reusable prompt templates the developer runs **on demand** from the Copilot Chat prompt picker. Used for review checklists and guided workflows. | Standardize repetitive developer workflows (reviews, audits, migrations) into shareable, version-controlled templates that any team member can invoke identically. |
 | **skills** | `skills/*/SKILL.md` | Self-contained workflow guides that the AI agent **discovers automatically** when the user's question matches the skill description. Each skill covers one topic end-to-end. | Encode deep domain knowledge (decision trees, pitfalls, end-to-end examples) in modular documents the agent retrieves on demand, enabling expert-level guidance without overloading the base context. |
-| **agents** | `.github/agents/*.agent.md` | Custom agent modes that appear in the Copilot Chat **agent picker**. Each defines a specialized AI persona with its own system prompt, allowed tools, and constraints. | Create purpose-built agent configurations for recurring workflows (e.g. a "reviewer" agent that only reads files and runs tests, or a "docs" agent restricted to documentation folders) so developers get a tailored experience without manual prompt engineering. |
+| **agents** | `.github/agents/*.agent.md` | Optional custom agent modes that appear in the Copilot Chat **agent picker** when such files exist. This repository does not currently define custom agents. | Future extension point for purpose-built agent configurations (e.g. a "reviewer" agent that only reads files and runs tests, or a "docs" agent restricted to documentation folders) so developers get a tailored experience without manual prompt engineering. |
 | **AGENTS.md** | `AGENTS.md` (repo root) | Equivalent to `copilot-instructions.md` but for IDEs that follow the AGENTS.md convention (Claude Code, Codex CLI, Aider). Same content, different standard. | Ensure consistent AI behaviour across different IDEs and tools by providing the same project context through each tool's native convention. |
 
 ### Analogy: cooking a dish
@@ -23,7 +23,7 @@ Imagine you hire a chef (the AI) to work in your kitchen (the repo).
 - **instructions** are **station cards** taped next to each workstation: "at the grill, sear 2 min per side" or "at the pastry station, always sift flour." The chef only reads the card for the station she's working at right now.
 - **prompts** are **recipe cards** in a drawer. The chef never opens the drawer on her own — you hand her a specific card when you say "follow this exact recipe for the soufflé." She executes it step by step, once.
 - **skills** are **cooking reference books** on the shelf (one for sauces, one for bread, one for plating). The chef pulls one down when you ask something like "how do I make a béchamel?" — she knows which book to grab by the topic.
-- **agents** are **specialist hats**. When you say "today you're the pastry chef," the chef puts on that hat and only works with desserts, pastry tools, and pastry rules. Switch to "grill master" and her focus, tools, and constraints change entirely.
+- **agents** are **specialist hats**. When they exist, selecting one changes the chef's focus, tools, and constraints for the whole session.
 
 | Kitchen analogy | AI file type | Loaded when |
 |-----------------|-------------|-------------|
@@ -81,7 +81,7 @@ Files in `skills/*/SKILL.md` are **specialized workflow guides** that AI agents 
 
 ### .agent.md files (custom agent modes)
 
-Files in `.github/agents/` define **custom agent modes** that appear in the Copilot Chat agent picker (the model/mode dropdown). Each `.agent.md` file creates a specialized AI persona with its own system prompt and, optionally, restricted tools or scoped instructions.
+Files in `.github/agents/` define **custom agent modes** that appear in the Copilot Chat agent picker (the model/mode dropdown). Each `.agent.md` file creates a specialized AI persona with its own system prompt and, optionally, restricted tools or scoped instructions. skforecast does not currently ship custom agents; this is documented as a future extension point.
 
 - **When**: only when the user selects the agent mode from the picker
 - **Scope**: entire conversation while that mode is active
@@ -107,7 +107,7 @@ Loaded when file pattern matches:
 Loaded on demand by AI agent:
   └─ skills/*/SKILL.md                       (topic-specific workflows)
 
-Loaded when user selects agent mode:
+Optional future extension if agent files are added:
   └─ .github/agents/*.agent.md               (custom agent personas)
 
 Loaded when user explicitly invokes:
@@ -128,8 +128,8 @@ These are the only files you edit directly:
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `tools/ai/llms-base.txt` | ~730 | Core API reference: all forecasters, imports, examples, workflows |
-| `tools/ai/ai_context_header.md` | ~95 | Dev-only context: testing commands, code style, dependencies |
+| `tools/ai/llms-base.txt` | ~650 | Core API reference: all forecasters, imports, examples, workflows |
+| `tools/ai/ai_context_header.md` | ~30 | Dev-only context: testing commands, code style, dependencies |
 | `llms.txt` (root) | ~120 | Public index per [llmstxt.org](https://llmstxt.org) spec with links to docs |
 | `skills/*/SKILL.md` | 13 skills | Modular workflow guides, one per topic |
 | `skills/*/references/*.md` | 7 files | Supplementary reference tables for some skills |
@@ -144,9 +144,9 @@ All marked with `<!-- AUTO-GENERATED -->` header and tracked in `.gitattributes`
 |------|--------|---------|
 | `.github/copilot-instructions.md` | header + llms-base | IDE context for GitHub Copilot |
 | `AGENTS.md` | header + llms-base | IDE context for Claude Code, Codex, Aider |
-| `llms-full.txt` | llms-base + 13 skills | Complete LLM reference (~2500 lines) |
-| `docs/llms.txt` | copy of root `llms.txt` | Served at skforecast.org/llms.txt |
-| `docs/llms-full.txt` | copy of `llms-full.txt` | Served at skforecast.org/llms-full.txt |
+| `llms-full.txt` | llms-base + 13 skills | Complete LLM reference (~5000 lines) |
+| `docs/llms.txt` | copy of root `llms.txt` | Served at skforecast.org/latest/llms.txt |
+| `docs/llms-full.txt` | copy of `llms-full.txt` | Served at skforecast.org/latest/llms-full.txt |
 
 ## Skills
 

--- a/tools/ai/generate_ai_context_files.py
+++ b/tools/ai/generate_ai_context_files.py
@@ -21,6 +21,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import sys
 import textwrap
@@ -34,6 +35,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 AI_DIR = Path(__file__).resolve().parent
+PYPROJECT_LLM_CONTEXT_RE = re.compile(
+    r'^"LLM Context"\s*=\s*"([^"]+)"', re.MULTILINE
+)
+ALLOWED_REDIRECT_PREFIXES = ("https://doi.org/",)
 
 SKILL_ORDER: list[str] = [
     "forecasting-single-series",
@@ -74,6 +79,8 @@ AUTOGEN_NOTICE_FULL = textwrap.dedent("""\
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
 def strip_yaml_frontmatter(text: str) -> str:
     """Remove YAML front-matter delimited by ``---`` from *text*."""
     if text.startswith("---"):
@@ -131,6 +138,24 @@ def validate_skill(skill_dir: Path) -> list[str]:
     line_count = body.count("\n") + 1
     if line_count > 500:
         errors.append(f"  {name}: SKILL.md body is {line_count} lines (max 500)")
+
+    # --- references ---
+    refs_dir = skill_dir / "references"
+    if refs_dir.exists():
+        for ref_file in sorted(refs_dir.glob("*.md")):
+            ref_body = ref_file.read_text(encoding="utf-8")
+            if not ref_body.strip():
+                errors.append(f"  {name}: references/{ref_file.name} is empty")
+            ref_line_count = ref_body.count("\n") + 1
+            if ref_line_count > 1000:
+                errors.append(
+                    f"  {name}: references/{ref_file.name} is "
+                    f"{ref_line_count} lines (max 1000)"
+                )
+            if f"references/{ref_file.name}" not in raw:
+                errors.append(
+                    f"  {name}: references/{ref_file.name} is not linked from SKILL.md"
+                )
 
     # --- name must be in SKILL_ORDER ---
     if name not in SKILL_ORDER:
@@ -199,7 +224,8 @@ def validate_imports_consistency() -> list[str]:
     subpackages = [
         "recursive", "direct", "preprocessing", "model_selection",
         "feature_selection", "metrics", "datasets", "stats",
-        "drift_detection", "deep_learning", "foundation",
+        "drift_detection", "deep_learning", "foundation", "plot",
+        "exceptions", "experimental",
     ]
 
     for pkg in subpackages:
@@ -250,111 +276,161 @@ def validate_imports_consistency() -> list[str]:
     return errors
 
 
-def validate_llms_txt_urls(
-    ignore_patterns: list[str] | None = None,
-) -> list[str]:
-    """Check that all URLs in llms.txt (root) are reachable.
+def extract_urls(text: str) -> list[str]:
+    """Extract markdown and bare HTTP(S) URLs from text."""
+    urls: list[str] = re.findall(r"\(\s*(https?://[^)\s]+)\s*\)", text)
+    urls.extend(re.findall(r"\bhttps?://[^\s)>\"']+", text))
 
-    Extracts markdown links ``[text](url)`` and plain URLs, then sends
-    HTTP HEAD requests. Reports unreachable, redirected, or error URLs.
-
-    Parameters
-    ----------
-    ignore_patterns : list[str] or None
-        Substrings to match against URLs. Any URL containing one of these
-        substrings is skipped (useful for URLs pending deployment).
-    """
-    errors: list[str] = []
-    llms_path = ROOT / 'llms.txt'
-    if not llms_path.exists():
-        errors.append('  llms.txt not found at repository root')
-        return errors
-
-    text = llms_path.read_text(encoding='utf-8')
-
-    # Extract URLs from markdown links [text](url) and bare https:// URLs
-    urls: list[str] = re.findall(r'\(\s*(https?://[^)\s]+)\s*\)', text)
-    bare = re.findall(r'(?<!\()\b(https?://[^\s)>]+)', text)
     seen: set[str] = set()
-    all_urls: list[str] = []
-    for u in urls + bare:
-        u = u.rstrip('.,;:')
-        if u not in seen:
-            seen.add(u)
-            all_urls.append(u)
+    unique_urls: list[str] = []
+    for url in urls:
+        clean_url = url.rstrip(".,;:)'\"")
+        if clean_url not in seen:
+            seen.add(clean_url)
+            unique_urls.append(clean_url)
 
-    if not all_urls:
-        errors.append('  llms.txt: no URLs found')
-        return errors
+    return unique_urls
 
-    # Filter out ignored URLs
-    if ignore_patterns:
-        filtered: list[str] = []
-        skipped: list[str] = []
-        for u in all_urls:
-            if any(pat in u for pat in ignore_patterns):
-                skipped.append(u)
-            else:
-                filtered.append(u)
-        if skipped:
-            print(f'  Skipping {len(skipped)} URL(s) matching --ignore-urls:')
-            for s in skipped:
-                print(f'    {s}')
-        all_urls = filtered
 
-    if not all_urls:
-        print('  All URLs were ignored, nothing to check.')
-        return errors
-
-    print(f'  Checking {len(all_urls)} URLs in llms.txt ...')
-
-    ok_count = 0
-    redirects: list[str] = []
-    for url in all_urls:
+def check_url(url: str, label: str) -> list[str]:
+    """Check a URL with HEAD and fallback to GET."""
+    errors: list[str] = []
+    allow_redirect = any(
+        url.startswith(prefix) for prefix in ALLOWED_REDIRECT_PREFIXES
+    )
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        req.add_header("User-Agent", "skforecast-link-checker/1.0")
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            code = resp.getcode()
+            if code and code >= 400:
+                errors.append(f"  {label}: HTTP {code} - {url}")
+            elif resp.url != url and not allow_redirect:
+                errors.append(f"  {label}: redirected {url} -> {resp.url}")
+    except urllib.error.HTTPError as exc:
+        # Some servers reject HEAD; retry with GET
         try:
-            req = urllib.request.Request(url, method='HEAD')
-            req.add_header('User-Agent', 'skforecast-link-checker/1.0')
-            with urllib.request.urlopen(req, timeout=15) as resp:
+            req_get = urllib.request.Request(url, method="GET")
+            req_get.add_header("User-Agent", "skforecast-link-checker/1.0")
+            with urllib.request.urlopen(req_get, timeout=15) as resp:
                 code = resp.getcode()
                 if code and code >= 400:
-                    errors.append(f'  llms.txt: HTTP {code} — {url}')
-                else:
-                    if resp.url != url:
-                        redirects.append(
-                            f'  llms.txt: redirected {url} -> {resp.url}'
-                        )
-                    ok_count += 1
-        except urllib.error.HTTPError as exc:
-            # Some servers reject HEAD; retry with GET
-            try:
-                req_get = urllib.request.Request(url, method='GET')
-                req_get.add_header('User-Agent', 'skforecast-link-checker/1.0')
-                with urllib.request.urlopen(req_get, timeout=15) as resp:
-                    code = resp.getcode()
-                    if code and code >= 400:
-                        errors.append(f'  llms.txt: HTTP {code} — {url}')
-                    else:
-                        if resp.url != url:
-                            redirects.append(
-                                f'  llms.txt: redirected {url} -> {resp.url}'
-                            )
-                        ok_count += 1
-            except Exception:
-                errors.append(f'  llms.txt: HTTP {exc.code} — {url}')
-        except urllib.error.URLError as exc:
-            errors.append(f'  llms.txt: Connection error ({exc.reason}) — {url}')
-        except Exception as exc:
-            errors.append(f'  llms.txt: {exc} — {url}')
+                    errors.append(f"  {label}: HTTP {code} - {url}")
+                elif resp.url != url and not allow_redirect:
+                    errors.append(f"  {label}: redirected {url} -> {resp.url}")
+        except Exception:
+            errors.append(f"  {label}: HTTP {exc.code} - {url}")
+    except urllib.error.URLError as exc:
+        errors.append(f"  {label}: Connection error ({exc.reason}) - {url}")
+    except Exception as exc:
+        errors.append(f"  {label}: {exc} - {url}")
 
-    if redirects:
-        print(f'  {len(redirects)} URL(s) redirected:')
-        for r in redirects:
-            print(r)
-        errors.extend(redirects)
+    return errors
+
+
+def validate_urls_in_file(
+    path: Path,
+    label: str,
+    ignore_patterns: list[str] | None = None,
+) -> list[str]:
+    """Check all URLs in a text file are reachable and canonical."""
+    errors: list[str] = []
+    if not path.exists():
+        return [f"  {label}: file not found at {path.relative_to(ROOT)}"]
+
+    urls = extract_urls(path.read_text(encoding="utf-8"))
+    if ignore_patterns:
+        urls = [
+            url for url in urls
+            if not any(pattern in url for pattern in ignore_patterns)
+        ]
+
+    if not urls:
+        return [f"  {label}: no URLs found"]
+
+    print(f"  Checking {len(urls)} URLs in {label} ...")
+    for url in urls:
+        errors.extend(check_url(url, label))
 
     if not errors:
-        print(f'  All {ok_count} URLs are reachable.')
+        print(f"  All {len(urls)} URLs in {label} are reachable.")
 
+    return errors
+
+
+def validate_pyproject_llm_context_url() -> list[str]:
+    """Check the PyPI metadata LLM Context URL."""
+    pyproject_path = ROOT / "pyproject.toml"
+    if not pyproject_path.exists():
+        return ["  pyproject.toml: file not found"]
+
+    text = pyproject_path.read_text(encoding="utf-8")
+    match = PYPROJECT_LLM_CONTEXT_RE.search(text)
+    if not match:
+        return ["  pyproject.toml: missing project URL 'LLM Context'"]
+
+    url = match.group(1)
+    print("  Checking LLM Context URL in pyproject.toml ...")
+    errors = check_url(url, "pyproject.toml LLM Context")
+    if not errors:
+        print("  LLM Context URL in pyproject.toml is reachable.")
+
+    return errors
+
+
+def validate_python_snippets() -> list[str]:
+    """Syntax-check executable Python snippets in AI context source files."""
+    errors: list[str] = []
+    source_files: list[Path] = [AI_DIR / "llms-base.txt"]
+    source_files.extend((ROOT / "skills").glob("*/SKILL.md"))
+    source_files.extend((ROOT / "skills").glob("*/references/*.md"))
+
+    # Signature reference blocks intentionally use non-executable notation.
+    skip_files = {
+        ROOT
+        / "skills"
+        / "complete-api-reference"
+        / "references"
+        / "method-signatures.md",
+    }
+
+    for path in sorted(source_files):
+        if path in skip_files or not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(
+            r"^[ \t]*```python\n(.*?)\n[ \t]*```",
+            text,
+            re.DOTALL | re.MULTILINE,
+        ):
+            snippet = textwrap.dedent(match.group(1))
+            try:
+                ast.parse(snippet)
+            except SyntaxError as exc:
+                relpath = path.relative_to(ROOT)
+                errors.append(
+                    f"  {relpath}: invalid Python snippet near line "
+                    f"{text[:match.start()].count(chr(10)) + exc.lineno + 1}: "
+                    f"{exc.msg}"
+                )
+
+    return errors
+
+
+def validate_ai_context_urls(
+    ignore_patterns: list[str] | None = None,
+) -> list[str]:
+    """Check AI context URLs exposed to users and package metadata."""
+    errors: list[str] = []
+    errors.extend(
+        validate_urls_in_file(ROOT / "llms.txt", "llms.txt", ignore_patterns)
+    )
+    errors.extend(
+        validate_urls_in_file(
+            AI_DIR / "llms-base.txt", "tools/ai/llms-base.txt", ignore_patterns
+        )
+    )
+    errors.extend(validate_pyproject_llm_context_url())
     return errors
 
 
@@ -432,6 +508,9 @@ def generate(*, check_only: bool = False) -> bool:
 
     # ── validate imports consistency ─────────────────────────────────
     all_errors.extend(validate_imports_consistency())
+
+    # ── validate Python snippets ─────────────────────────────────────
+    all_errors.extend(validate_python_snippets())
 
     if all_errors:
         print("Validation errors:")
@@ -511,9 +590,9 @@ def main() -> None:
     ok = generate(check_only=args.check)
 
     if args.check_urls:
-        url_errors = validate_llms_txt_urls(ignore_patterns=args.ignore_urls)
+        url_errors = validate_ai_context_urls(ignore_patterns=args.ignore_urls)
         if url_errors:
-            print('\nURL validation errors in llms.txt:')
+            print('\nURL validation errors in AI context files:')
             for e in url_errors:
                 print(e)
             ok = False

--- a/tools/ai/llms-base.txt
+++ b/tools/ai/llms-base.txt
@@ -396,7 +396,7 @@ def search_space(trial):
         'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True)
     }
 
-results, best_trial = bayesian_search_forecaster(
+results, study = bayesian_search_forecaster(
     forecaster=forecaster,
     y=data['target'],
     cv=cv,
@@ -408,6 +408,7 @@ results, best_trial = bayesian_search_forecaster(
     n_jobs='auto',
     show_progress=True
 )
+# Access the best trial with study.best_trial
 ```
 
 ## Statistical Models (ARIMA, ETS, ARAR)
@@ -599,8 +600,26 @@ from skforecast.plot import backtesting_gif_creator
 from skforecast.plot import set_dark_theme
 
 # Exceptions and Warnings
+from skforecast.exceptions import DataTypeWarning
+from skforecast.exceptions import DataTransformationWarning
+from skforecast.exceptions import ExogenousInterpretationWarning
+from skforecast.exceptions import FeatureOutOfRangeWarning
+from skforecast.exceptions import IgnoredArgumentWarning
+from skforecast.exceptions import InputTypeWarning
+from skforecast.exceptions import LongTrainingWarning
+from skforecast.exceptions import MissingExogWarning
+from skforecast.exceptions import MissingValuesWarning
+from skforecast.exceptions import OneStepAheadValidationWarning
+from skforecast.exceptions import ResidualsUsageWarning
+from skforecast.exceptions import SaveLoadSkforecastWarning
+from skforecast.exceptions import SkforecastVersionWarning
+from skforecast.exceptions import UnknownLevelWarning
 from skforecast.exceptions import set_warnings_style
 from skforecast.exceptions import warn_skforecast_categories
+from skforecast.exceptions import runtime_deprecated
+
+# Experimental
+from skforecast.experimental import calculate_distance_from_holiday
 ```
 
 ## Available Datasets


### PR DESCRIPTION
…cumentation and examples

- Changed return value of bayesian_search_forecaster and related functions to include the Optuna study object instead of best trial.
- Updated all relevant documentation and examples to reflect the new return structure.
- Added new exceptions imports for better error handling.
- Enhanced validation checks for URLs in AI context files and added Python snippet validation.
- Updated links in llms.txt to point to the latest API documentation.
- Improved formatting and consistency in SKILL.md files across various skills.