### PR TITLE
refactor: centralize multi-estimator handling in MultiEstimatorMixin

### DIFF
--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -35,6 +35,8 @@ The main changes in this release are:
 
 **Fixed**
 
++ Fix a bug in <code>[ForecasterStats]</code> where the `remove_estimators` method was not deleting the corresponding estimator parameters.
+
 
 ## 0.22.0 <small>Apr 23, 2026</small> { id="0.22.0" }
 

--- a/skforecast/base/__init__.py
+++ b/skforecast/base/__init__.py
@@ -1,1 +1,2 @@
 from ._forecaster_base import ForecasterBase
+from ._multi_estimator_mixin import MultiEstimatorMixin

--- a/skforecast/base/_multi_estimator_mixin.py
+++ b/skforecast/base/_multi_estimator_mixin.py
@@ -1,0 +1,265 @@
+################################################################################
+#                             MultiEstimatorMixin                              #
+#                                                                              #
+# This work by skforecast team is licensed under the BSD 3-Clause License.     #
+################################################################################
+# coding=utf-8
+
+from __future__ import annotations
+import pandas as pd
+
+from ..utils import check_select_fit_kwargs
+
+
+class MultiEstimatorMixin:
+    """
+    Mixin that adds management of multiple estimators to a forecaster.
+
+    This mixin is not meant to be instantiated on its own. It provides methods
+    to inspect and remove estimators in forecasters that hold more than one
+    estimator. The class using this mixin must initialize the following
+    attributes in its `__init__` method:
+
+    - `estimators` : list
+        Original (unfitted) estimator instances provided by the user.
+    - `estimators_` : list
+        Estimator instances that are trained when `fit()` is called.
+    - `estimator_ids` : list
+        Unique identifier for each estimator.
+    - `estimator_names_` : list
+        Descriptive name for each estimator.
+    - `estimator_types` : list
+        Full qualified type string for each estimator.
+    - `estimator_params_` : dict
+        Parameters of each estimator keyed by estimator id. Required by
+        `get_estimators_info`.
+    - `n_estimators` : int
+        Number of estimators in the forecaster.
+
+    The following attributes are optional. When present, `get_estimators_info`
+    adds the corresponding column to its output:
+
+    - `estimators_support_exog` : tuple
+        Estimator types that support exogenous variables (`supports_exog`).
+    - `estimators_support_interval` : tuple
+        Estimator types that support prediction intervals (`supports_interval`).
+
+    """
+
+    def _generate_estimator_ids(self) -> list[str]:
+        """
+        Generate unique estimator ids for a list of estimators.
+
+        Handles duplicate estimator ids by appending a numeric suffix.
+        
+        Returns
+        -------
+        estimator_ids : list[str]
+            List of unique ids for each estimator.
+        
+        """
+
+        estimator_ids = []
+        id_counts = {}
+        for est in self.estimators:
+            base_id = f"{type(est).__module__.split('.')[0]}.{type(est).__name__}"
+
+            # Track occurrences and add suffix for duplicates
+            if base_id in id_counts:
+                id_counts[base_id] += 1
+                unique_id = f"{base_id}_{id_counts[base_id]}"
+            else:
+                id_counts[base_id] = 1
+                unique_id = base_id
+
+            estimator_ids.append(unique_id)
+
+        return estimator_ids
+
+    def _build_estimators_repr_html(
+        self, estimator_params: list[str]
+    ) -> tuple[str, str]:
+        """
+        Build the HTML blocks for the estimators list and their parameters used
+        in the `_repr_html_` method.
+
+        Parameters
+        ----------
+        estimator_params : list
+            Formatted parameters of each estimator as returned by
+            `_preprocess_repr`.
+
+        Returns
+        -------
+        estimators_html : str
+            HTML block listing each estimator id and name.
+        params_html : str
+            HTML block listing the parameters of each estimator.
+
+        """
+
+        estimators_html = "<ul>"
+        for est_id, est_name in zip(self.estimator_ids, self.estimator_names_):
+            if est_name is not None:
+                estimators_html += f"<li>{est_id}: {est_name}</li>"
+            else:
+                estimators_html += f"<li>{est_id}</li>"
+        estimators_html += "</ul>"
+
+        if len(estimator_params) == 1:
+            params_html = f"<ul><li>{estimator_params[0]}</li></ul>"
+        else:
+            params_html = "<ul>"
+            for param in estimator_params:
+                params_html += f"<li>{param}</li>"
+            params_html += "</ul>"
+
+        return estimators_html, params_html
+
+    def _check_select_fit_kwargs(
+        self, fit_kwargs: dict[str, object] | None = None
+    ) -> dict[str, dict[str, object]]:
+        """
+        Select, for each estimator, the keyword arguments accepted by its `fit`
+        method. The same `fit_kwargs` provided by the user is validated against
+        every estimator, since each one may expose a different `fit` signature.
+
+        Parameters
+        ----------
+        fit_kwargs : dict, default None
+            Dictionary with the arguments to pass to the `fit` method of the
+            estimators.
+
+        Returns
+        -------
+        fit_kwargs : dict
+            Dictionary with the selected arguments for each estimator keyed by
+            estimator id.
+
+        """
+
+        return {
+            est_id: check_select_fit_kwargs(estimator=est, fit_kwargs=fit_kwargs)
+            for est_id, est in zip(self.estimator_ids, self.estimators)
+        }
+
+    def get_estimator(self, id: str) -> object:
+        """
+        Get a specific estimator by its id.
+        
+        Parameters
+        ----------
+        id : str
+            The id of the estimator to retrieve.
+        
+        Returns
+        -------
+        estimator : object
+            The requested estimator instance.
+        
+        """
+        
+        if id not in self.estimator_ids:
+            raise KeyError(
+                f"No estimator with id '{id}'. "
+                f"Available estimators: {self.estimator_ids}"
+            )
+        
+        idx = self.estimator_ids.index(id)
+
+        return self.estimators_[idx]
+    
+    def get_estimator_ids(self) -> list[str]:
+        """
+        Get the ids of all estimators in the forecaster.
+        
+        Returns
+        -------
+        estimator_ids : list[str]
+            List of estimator ids.
+        
+        """
+
+        return self.estimator_ids
+    
+    def remove_estimators(self, ids: str | list[str]) -> None:
+        """
+        Remove one or more estimators by their ids.
+        
+        Parameters
+        ----------
+        ids : str, list[str]
+            The ids of the estimators to remove.
+        
+        Returns
+        -------
+        None
+        
+        """
+
+        if isinstance(ids, str):
+            ids = [ids]
+        
+        missing_ids = [id for id in ids if id not in self.estimator_ids]
+        if missing_ids:
+            raise KeyError(
+                f"No estimator(s) with id '{missing_ids}'. "
+                f"Available estimators: {self.estimator_ids}"
+            )
+            
+        for id in ids:
+            idx = self.estimator_ids.index(id)
+            del self.estimators[idx]
+            del self.estimators_[idx]
+            del self.estimator_ids[idx]
+            del self.estimator_names_[idx]
+            del self.estimator_types[idx]
+            del self.estimator_params_[id]
+            self.n_estimators -= 1
+
+    def get_estimators_info(self) -> pd.DataFrame:
+        """
+        Get a summary DataFrame with information about all estimators in the 
+        forecaster.
+        
+        Returns
+        -------
+        info : pandas DataFrame
+            DataFrame with columns:
+
+            - id: Unique identifier for each estimator.
+            - name: Descriptive name (available after fitting).
+            - type: Full qualified type string.
+            - supports_exog: Whether the estimator supports exogenous variables.
+            Only included if the forecaster defines `estimators_support_exog`.
+            - supports_interval: Whether the estimator supports prediction
+            intervals. Only included if the forecaster defines
+            `estimators_support_interval`.
+            - params: Dictionary of the estimator parameters.
+        
+        """
+
+        info = {
+            'id': self.estimator_ids,
+            'name': self.estimator_names_,
+            'type': self.estimator_types,
+        }
+
+        if hasattr(self, 'estimators_support_exog'):
+            info['supports_exog'] = [
+                est_type in self.estimators_support_exog
+                for est_type in self.estimator_types
+            ]
+        if hasattr(self, 'estimators_support_interval'):
+            info['supports_interval'] = [
+                est_type in self.estimators_support_interval
+                for est_type in self.estimator_types
+            ]
+
+        info['params'] = [
+            str(self.estimator_params_[est_id]) for est_id in self.estimator_ids
+        ]
+
+        info = pd.DataFrame(info)
+
+        return info

--- a/skforecast/base/tests/tests_multi_estimator_mixin/test_estimator_methods.py
+++ b/skforecast/base/tests/tests_multi_estimator_mixin/test_estimator_methods.py
@@ -1,0 +1,462 @@
+# Unit test MultiEstimatorMixin
+# ==============================================================================
+import re
+import pytest
+import pandas as pd
+from sklearn.base import BaseEstimator, clone
+from sklearn.linear_model import LinearRegression, Ridge
+from sklearn.ensemble import RandomForestRegressor
+from skforecast.base import MultiEstimatorMixin
+from skforecast.exceptions import IgnoredArgumentWarning
+
+
+class CustomFitEstimator(BaseEstimator):
+    """
+    Minimal estimator whose `fit` method accepts a distinctive keyword argument
+    (`custom_arg`) not present in scikit-learn estimators. Used to verify that
+    `_check_select_fit_kwargs` selects keyword arguments per estimator according
+    to each `fit` signature.
+    """
+
+    def fit(self, X, y, custom_arg=None):
+        return self
+
+
+class DummyForecaster(MultiEstimatorMixin):
+    """
+    Minimal class implementing the MultiEstimatorMixin attribute contract,
+    used to test the mixin in isolation. Ids are generated with the real
+    `_generate_estimator_ids` method, while `estimators_` are cloned so the
+    fitted estimators differ from the original (unfitted) ones.
+    `estimator_types` and `estimator_names_` use synthetic values to verify
+    index alignment after removal.
+    """
+
+    def __init__(self, estimators):
+        self.estimators = list(estimators)
+        self.estimators_ = [clone(est) for est in self.estimators]
+        self.estimator_ids = self._generate_estimator_ids()
+        self.estimator_types = [f"type_{i}" for i in range(len(self.estimators))]
+        self.estimator_names_ = [f"name_{i}" for i in range(len(self.estimators))]
+        self.n_estimators = len(self.estimators)
+        self.estimator_params_ = {
+            est_id: est.get_params()
+            for est_id, est in zip(self.estimator_ids, self.estimators_)
+        }
+
+
+# Test _generate_estimator_ids
+# ==============================================================================
+def test_generate_estimator_ids_output_when_no_duplicates():
+    """
+    Test that unique estimators return ids without numeric suffix.
+    """
+    estimators = [LinearRegression(), Ridge(), RandomForestRegressor()]
+    forecaster = DummyForecaster(estimators=estimators)
+    results = forecaster._generate_estimator_ids()
+    
+    expected = [
+        'sklearn.LinearRegression',
+        'sklearn.Ridge',
+        'sklearn.RandomForestRegressor',
+    ]
+
+    assert results == expected
+
+
+def test_generate_estimator_ids_output_when_duplicates():
+    """
+    Test that duplicate estimators get a numeric suffix appended in order.
+    """
+    estimators = [
+        LinearRegression(),
+        LinearRegression(),
+        Ridge(),
+        LinearRegression(),
+    ]
+    forecaster = DummyForecaster(estimators=estimators)
+    results = forecaster._generate_estimator_ids()
+
+    expected = [
+        'sklearn.LinearRegression',
+        'sklearn.LinearRegression_2',
+        'sklearn.Ridge',
+        'sklearn.LinearRegression_3',
+    ]
+
+    assert results == expected
+
+
+@pytest.mark.parametrize(
+    'estimators, expected',
+    [
+        ([LinearRegression()], ['sklearn.LinearRegression']),
+        (
+            [Ridge(), Ridge()],
+            ['sklearn.Ridge', 'sklearn.Ridge_2'],
+        ),
+    ],
+    ids=lambda x: f'estimators: {x}'
+)
+def test_generate_estimator_ids_output_parametrized(estimators, expected):
+    """
+    Test ids generated for single and duplicated estimators.
+    """
+    forecaster = DummyForecaster(estimators=estimators)
+    results = forecaster._generate_estimator_ids()
+
+    assert results == expected
+
+
+# Test get_estimator
+# ==============================================================================
+def test_get_estimator_raises_KeyError_when_id_not_found():
+    """
+    Raise KeyError when estimator id is not found.
+    """
+    forecaster = DummyForecaster(estimators=[LinearRegression()])
+
+    err_msg = re.escape(
+        "No estimator with id 'invalid_id'. "
+        "Available estimators: ['sklearn.LinearRegression']"
+    )
+    with pytest.raises(KeyError, match=err_msg):
+        forecaster.get_estimator('invalid_id')
+
+
+def test_get_estimator_returns_correct_estimator():
+    """
+    Check that get_estimator returns the correct estimator by id.
+    """
+    estimators = [LinearRegression(), Ridge()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    estimator = forecaster.get_estimator('sklearn.Ridge')
+
+    assert isinstance(estimator, Ridge)
+    assert estimator is forecaster.estimators_[1]
+
+
+def test_get_estimator_returns_correct_estimator_with_suffix():
+    """
+    Check that get_estimator returns the correct estimator when id has suffix.
+    """
+    estimators = [LinearRegression(), LinearRegression()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    estimator_1 = forecaster.get_estimator('sklearn.LinearRegression')
+    estimator_2 = forecaster.get_estimator('sklearn.LinearRegression_2')
+
+    assert estimator_1 is forecaster.estimators_[0]
+    assert estimator_2 is forecaster.estimators_[1]
+
+
+def test_get_estimator_returns_fitted_estimator():
+    """
+    Check that the estimator returned by get_estimator is the version stored in
+    `estimators_`, not the original one stored in `estimators`.
+    """
+    forecaster = DummyForecaster(estimators=[LinearRegression()])
+
+    estimator = forecaster.get_estimator(id='sklearn.LinearRegression')
+
+    # estimators_ contains the (fitted) estimators, estimators the originals
+    assert estimator is forecaster.estimators_[0]
+    assert estimator is not forecaster.estimators[0]
+
+
+# Test get_estimator_ids
+# ==============================================================================
+def test_get_estimator_ids_returns_list_of_ids():
+    """
+    Check that get_estimator_ids returns a list of all estimator ids.
+    """
+    estimators = [LinearRegression(), Ridge(), RandomForestRegressor()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    ids = forecaster.get_estimator_ids()
+
+    assert ids == [
+        'sklearn.LinearRegression',
+        'sklearn.Ridge',
+        'sklearn.RandomForestRegressor',
+    ]
+    assert ids is forecaster.estimator_ids
+
+
+def test_get_estimator_ids_returns_single_id():
+    """
+    Check that get_estimator_ids returns a list with single id.
+    """
+    forecaster = DummyForecaster(estimators=[LinearRegression()])
+
+    ids = forecaster.get_estimator_ids()
+
+    assert ids == ['sklearn.LinearRegression']
+
+
+def test_get_estimator_ids_with_duplicates():
+    """
+    Check that get_estimator_ids returns unique ids for duplicate estimators.
+    """
+    estimators = [Ridge(), Ridge(), Ridge()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    ids = forecaster.get_estimator_ids()
+
+    assert ids == ['sklearn.Ridge', 'sklearn.Ridge_2', 'sklearn.Ridge_3']
+
+
+# Test _check_select_fit_kwargs
+# ==============================================================================
+def test_check_select_fit_kwargs_TypeError_when_fit_kwargs_not_dict():
+    """
+    Raise TypeError when `fit_kwargs` is not a dict.
+    """
+    forecaster = DummyForecaster(estimators=[LinearRegression()])
+
+    err_msg = re.escape(
+        "Argument `fit_kwargs` must be a dict. Got <class 'list'>."
+    )
+    with pytest.raises(TypeError, match=err_msg):
+        forecaster._check_select_fit_kwargs(['not_a_dict'])
+
+
+def test_check_select_fit_kwargs_returns_empty_dict_per_estimator_when_None():
+    """
+    Check that an empty dict is returned for each estimator when `fit_kwargs`
+    is None.
+    """
+    estimators = [LinearRegression(), Ridge()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    results = forecaster._check_select_fit_kwargs()
+
+    expected = {'sklearn.LinearRegression': {}, 'sklearn.Ridge': {}}
+
+    assert results == expected
+
+
+def test_check_select_fit_kwargs_drops_sample_weight_with_warning():
+    """
+    Check that `sample_weight` is removed for every estimator and a warning is
+    issued.
+    """
+    forecaster = DummyForecaster(estimators=[LinearRegression()])
+
+    warn_msg = re.escape(
+        "The `sample_weight` argument is ignored. Use `weight_func` to pass "
+        "a function that defines the individual weights for each sample "
+        "based on its index."
+    )
+    with pytest.warns(IgnoredArgumentWarning, match=warn_msg):
+        results = forecaster._check_select_fit_kwargs({'sample_weight': [1, 2]})
+
+    assert results == {'sklearn.LinearRegression': {}}
+
+
+def test_check_select_fit_kwargs_selects_per_estimator_signature():
+    """
+    Check that the same `fit_kwargs` is validated against each estimator's `fit`
+    signature, keeping the argument only for the estimator that accepts it.
+    """
+    estimators = [LinearRegression(), CustomFitEstimator()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    warn_msg = re.escape(
+        "Argument/s ['custom_arg'] ignored since they are not used by the "
+        "estimator's `fit` method."
+    )
+    with pytest.warns(IgnoredArgumentWarning, match=warn_msg):
+        results = forecaster._check_select_fit_kwargs({'custom_arg': 1})
+
+    lr_id, custom_id = forecaster.estimator_ids
+    expected = {lr_id: {}, custom_id: {'custom_arg': 1}}
+
+    assert results == expected
+
+
+def test_check_select_fit_kwargs_keeps_kwarg_for_all_accepting_estimators():
+    """
+    Check that a keyword argument accepted by all estimators is kept for each
+    one, including estimators with duplicated ids.
+    """
+    estimators = [CustomFitEstimator(), CustomFitEstimator()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    results = forecaster._check_select_fit_kwargs({'custom_arg': 1})
+
+    first_id, second_id = forecaster.estimator_ids
+    expected = {first_id: {'custom_arg': 1}, second_id: {'custom_arg': 1}}
+
+    assert results == expected
+
+
+# Test remove_estimators
+# ==============================================================================
+def test_remove_estimators_raises_KeyError_when_id_not_found():
+    """
+    Raise KeyError when the estimator id to remove is not found.
+    """
+    forecaster = DummyForecaster(estimators=[LinearRegression()])
+
+    err_msg = re.escape(
+        "No estimator(s) with id '['invalid_id']'. "
+        "Available estimators: ['sklearn.LinearRegression']"
+    )
+    with pytest.raises(KeyError, match=err_msg):
+        forecaster.remove_estimators('invalid_id')
+
+
+def test_remove_estimators_raises_KeyError_when_multiple_ids_not_found():
+    """
+    Raise KeyError when multiple estimator ids to remove are not found.
+    """
+    estimators = [LinearRegression(), Ridge()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    err_msg = re.escape(
+        "No estimator(s) with id '['invalid_1', 'invalid_2']'. "
+        "Available estimators: ['sklearn.LinearRegression', 'sklearn.Ridge']"
+    )
+    with pytest.raises(KeyError, match=err_msg):
+        forecaster.remove_estimators(['invalid_1', 'invalid_2'])
+
+
+def test_remove_estimators_single_id():
+    """
+    Check that remove_estimators removes a single estimator by id and keeps
+    all contract attributes consistent.
+    """
+    estimators = [LinearRegression(), Ridge(), RandomForestRegressor()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    forecaster.remove_estimators('sklearn.Ridge')
+
+    assert forecaster.n_estimators == 2
+    assert forecaster.estimator_ids == [
+        'sklearn.LinearRegression', 'sklearn.RandomForestRegressor'
+    ]
+    assert len(forecaster.estimators) == 2
+    assert len(forecaster.estimators_) == 2
+    assert isinstance(forecaster.estimators[0], LinearRegression)
+    assert isinstance(forecaster.estimators[1], RandomForestRegressor)
+    assert forecaster.estimator_types == ['type_0', 'type_2']
+    assert forecaster.estimator_names_ == ['name_0', 'name_2']
+    assert list(forecaster.estimator_params_.keys()) == [
+        'sklearn.LinearRegression', 'sklearn.RandomForestRegressor'
+    ]
+
+
+def test_remove_estimators_multiple_ids():
+    """
+    Check that remove_estimators removes multiple estimators by ids.
+    """
+    estimators = [LinearRegression(), Ridge(), RandomForestRegressor()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    forecaster.remove_estimators(
+        ['sklearn.LinearRegression', 'sklearn.RandomForestRegressor']
+    )
+
+    assert forecaster.n_estimators == 1
+    assert forecaster.estimator_ids == ['sklearn.Ridge']
+    assert len(forecaster.estimators) == 1
+    assert len(forecaster.estimators_) == 1
+    assert isinstance(forecaster.estimators[0], Ridge)
+    assert forecaster.estimator_types == ['type_1']
+    assert forecaster.estimator_names_ == ['name_1']
+    assert list(forecaster.estimator_params_.keys()) == ['sklearn.Ridge']
+
+
+def test_remove_estimators_with_suffix():
+    """
+    Check that remove_estimators correctly removes estimator with suffix id.
+    """
+    estimators = [Ridge(), Ridge(), Ridge()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    forecaster.remove_estimators('sklearn.Ridge_2')
+
+    assert forecaster.n_estimators == 2
+    assert forecaster.estimator_ids == ['sklearn.Ridge', 'sklearn.Ridge_3']
+    assert len(forecaster.estimators) == 2
+    assert len(forecaster.estimators_) == 2
+    assert forecaster.estimator_types == ['type_0', 'type_2']
+    assert forecaster.estimator_names_ == ['name_0', 'name_2']
+    assert list(forecaster.estimator_params_.keys()) == [
+        'sklearn.Ridge', 'sklearn.Ridge_3'
+    ]
+
+
+# Test get_estimators_info
+# ==============================================================================
+def test_get_estimators_info_without_support_attributes():
+    """
+    Check that get_estimators_info returns id, name, type and params columns
+    when the forecaster does not define `estimators_support_exog` or
+    `estimators_support_interval`.
+    """
+    estimators = [LinearRegression(), Ridge()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    results = forecaster.get_estimators_info()
+
+    expected = pd.DataFrame({
+        'id': ['sklearn.LinearRegression', 'sklearn.Ridge'],
+        'name': ['name_0', 'name_1'],
+        'type': ['type_0', 'type_1'],
+        'params': [
+            str(LinearRegression().get_params()),
+            str(Ridge().get_params()),
+        ],
+    })
+
+    pd.testing.assert_frame_equal(results, expected)
+
+
+def test_get_estimators_info_with_support_attributes():
+    """
+    Check that get_estimators_info adds supports_exog and supports_interval
+    columns when the forecaster defines the corresponding attributes.
+    """
+    estimators = [LinearRegression(), Ridge()]
+    forecaster = DummyForecaster(estimators=estimators)
+    forecaster.estimators_support_exog = ('type_0',)
+    forecaster.estimators_support_interval = ('type_1',)
+
+    results = forecaster.get_estimators_info()
+
+    expected = pd.DataFrame({
+        'id': ['sklearn.LinearRegression', 'sklearn.Ridge'],
+        'name': ['name_0', 'name_1'],
+        'type': ['type_0', 'type_1'],
+        'supports_exog': [True, False],
+        'supports_interval': [False, True],
+        'params': [
+            str(LinearRegression().get_params()),
+            str(Ridge().get_params()),
+        ],
+    })
+
+    pd.testing.assert_frame_equal(results, expected)
+
+
+def test_get_estimators_info_after_remove_estimators():
+    """
+    Check that get_estimators_info stays consistent after removing an estimator.
+    """
+    estimators = [LinearRegression(), Ridge(), RandomForestRegressor()]
+    forecaster = DummyForecaster(estimators=estimators)
+
+    forecaster.remove_estimators('sklearn.Ridge')
+    results = forecaster.get_estimators_info()
+
+    assert results['id'].to_list() == [
+        'sklearn.LinearRegression', 'sklearn.RandomForestRegressor'
+    ]
+    assert results['type'].to_list() == ['type_0', 'type_2']
+    assert results['params'].to_list() == [
+        str(forecaster.estimator_params_['sklearn.LinearRegression']),
+        str(forecaster.estimator_params_['sklearn.RandomForestRegressor']),
+    ]

--- a/skforecast/deep_learning/_forecaster_rnn.py
+++ b/skforecast/deep_learning/_forecaster_rnn.py
@@ -416,7 +416,8 @@ class ForecasterRnn(ForecasterBase):
             "forecaster_name": "ForecasterRnn",
             "forecaster_task": "regression",
             "forecasting_scope": "global",  # single-series | global
-            "forecasting_strategy": "deep_learning",  # recursive | direct | deep_learning
+            "forecasting_strategy": "deep_learning",  # recursive | direct | deep_learning | foundation
+            "multiple_estimators": False,
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 

--- a/skforecast/direct/_forecaster_direct.py
+++ b/skforecast/direct/_forecaster_direct.py
@@ -606,7 +606,8 @@ class ForecasterDirect(ForecasterBase):
             "forecaster_name": "ForecasterDirect",
             "forecaster_task": "regression",
             "forecasting_scope": "single-series",  # single-series | global
-            "forecasting_strategy": "direct",   # recursive | direct | deep_learning
+            "forecasting_strategy": "direct",   # recursive | direct | deep_learning | foundation
+            "multiple_estimators": False,
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 

--- a/skforecast/direct/_forecaster_direct_multivariate.py
+++ b/skforecast/direct/_forecaster_direct_multivariate.py
@@ -567,7 +567,8 @@ class ForecasterDirectMultiVariate(ForecasterBase):
             "forecaster_name": "ForecasterDirectMultiVariate",
             "forecaster_task": "regression",
             "forecasting_scope": "global",  # single-series | global
-            "forecasting_strategy": "direct",  # recursive | direct | deep_learning
+            "forecasting_strategy": "direct",  # recursive | direct | deep_learning | foundation
+            "multiple_estimators": False,
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 

--- a/skforecast/foundation/_forecaster_foundation.py
+++ b/skforecast/foundation/_forecaster_foundation.py
@@ -146,8 +146,9 @@ class ForecasterFoundation:
             "library": "skforecast",
             "forecaster_name": "ForecasterFoundation",
             "forecaster_task": "regression",
-            "forecasting_scope": "single-series|multi-series",
+            "forecasting_scope": "single-series | global",
             "forecasting_strategy": "foundation",
+            "multiple_estimators": False, 
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 
@@ -164,8 +165,8 @@ class ForecasterFoundation:
                 "long-format pandas.DataFrame",
                 "dict[str, pandas.Series | pandas.DataFrame | None]",
             ],
-            "handles_missing_values_series": False,
-            "handles_missing_values_exog": False,
+            "handles_missing_values_series": True,
+            "handles_missing_values_exog": True,
 
             "supports_lags": False,
             "supports_window_features": False,

--- a/skforecast/recursive/_forecaster_equivalent_date.py
+++ b/skforecast/recursive/_forecaster_equivalent_date.py
@@ -233,7 +233,8 @@ class ForecasterEquivalentDate():
             "forecaster_name": "ForecasterEquivalentDate",
             "forecaster_task": "regression",
             "forecasting_scope": "single-series",  # single-series | global
-            "forecasting_strategy": "recursive",   # recursive | direct | deep_learning
+            "forecasting_strategy": "recursive",   # recursive | direct | deep_learning | foundation
+            "multiple_estimators": False,
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 

--- a/skforecast/recursive/_forecaster_recursive.py
+++ b/skforecast/recursive/_forecaster_recursive.py
@@ -411,7 +411,8 @@ class ForecasterRecursive(ForecasterBase):
             "forecaster_name": "ForecasterRecursive",
             "forecaster_task": "regression",
             "forecasting_scope": "single-series",  # single-series | global
-            "forecasting_strategy": "recursive",   # recursive | direct | deep_learning
+            "forecasting_strategy": "recursive",  # recursive | direct | deep_learning | foundation
+            "multiple_estimators": False, 
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 

--- a/skforecast/recursive/_forecaster_recursive_classifier.py
+++ b/skforecast/recursive/_forecaster_recursive_classifier.py
@@ -398,7 +398,8 @@ class ForecasterRecursiveClassifier(ForecasterBase):
             "forecaster_name": "ForecasterRecursiveClassifier",
             "forecaster_task": "classification",
             "forecasting_scope": "single-series",  # single-series | global
-            "forecasting_strategy": "recursive",   # recursive | direct | deep_learning
+            "forecasting_strategy": "recursive",   # recursive | direct | deep_learning | foundation
+            "multiple_estimators": False,
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 

--- a/skforecast/recursive/_forecaster_recursive_multiseries.py
+++ b/skforecast/recursive/_forecaster_recursive_multiseries.py
@@ -614,7 +614,8 @@ class ForecasterRecursiveMultiSeries(ForecasterBase):
             "forecaster_name": "ForecasterRecursiveMultiSeries",
             "forecaster_task": "regression",
             "forecasting_scope": "global",  # single-series | global
-            "forecasting_strategy": "recursive",  # recursive | direct | deep_learning
+            "forecasting_strategy": "recursive",  # recursive | direct | deep_learning | foundation
+            "multiple_estimators": False, 
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
 

--- a/skforecast/recursive/_forecaster_stats.py
+++ b/skforecast/recursive/_forecaster_stats.py
@@ -17,6 +17,7 @@ from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 
 from .. import __version__
+from ..base import MultiEstimatorMixin
 from ..exceptions import IgnoredArgumentWarning
 from ..utils import (
     check_y,
@@ -33,7 +34,7 @@ from ..utils import (
 )
 
 
-class ForecasterStats():
+class ForecasterStats(MultiEstimatorMixin):
     """
     This class turns statistical models into a Forecaster compatible with the 
     skforecast API. It supports single or multiple statistical models for the 
@@ -218,7 +219,7 @@ class ForecasterStats():
         # aggregates predictions from all estimators.
         self.estimators              = estimator
         self.estimators_             = [clone(est) for est in self.estimators]
-        self.estimator_ids           = self._generate_ids(self.estimators)
+        self.estimator_ids           = self._generate_estimator_ids()
         self.estimator_types         = estimator_types
         self.estimator_names_        = [None] * len(self.estimators)
         self.n_estimators            = len(self.estimators)
@@ -311,7 +312,7 @@ class ForecasterStats():
             "forecaster_name": "ForecasterStats",
             "forecaster_task": "regression",
             "forecasting_scope": "single-series",  # single-series | global
-            "forecasting_strategy": "recursive",   # recursive | direct | deep_learning
+            "forecasting_strategy": "recursive",   # recursive | direct | deep_learning | foundation
             "multiple_estimators": True,
             "index_types_supported": ["pandas.RangeIndex", "pandas.DatetimeIndex"],
             "requires_index_frequency": True,
@@ -335,116 +336,6 @@ class ForecasterStats():
             "probabilistic_methods": ["distribution"],
             "handles_binned_residuals": False
         }
-
-    def _generate_ids(self, estimators: list) -> list[str]:
-        """
-        Generate unique ids for a list of estimators. Handles duplicate ids by 
-        appending a numeric suffix.
-        
-        Parameters
-        ----------
-        estimators : list
-            List of statistical model instances.
-        
-        Returns
-        -------
-        ids : list[str]
-            List of unique ids for each estimator.
-        
-        """
-
-        ids = []
-        id_counts = {}
-        for est in estimators:
-
-            base_id = (
-                f"{type(est).__module__.split('.')[0]}.{type(est).__name__}"
-            )
-            
-            # Track occurrences and add suffix for duplicates
-            if base_id in id_counts:
-                id_counts[base_id] += 1
-                unique_id = f"{base_id}_{id_counts[base_id]}"
-            else:
-                id_counts[base_id] = 1
-                unique_id = base_id
-            
-            ids.append(unique_id)
-        
-        return ids
-
-    def get_estimator(self, id: str) -> object:
-        """
-        Get a specific estimator by its id.
-        
-        Parameters
-        ----------
-        id : str
-            The id of the estimator to retrieve.
-        
-        Returns
-        -------
-        estimator : object
-            The requested estimator instance.
-        
-        """
-        
-        if id not in self.estimator_ids:
-            raise KeyError(
-                f"No estimator with id '{id}'. "
-                f"Available estimators: {self.estimator_ids}"
-            )
-        
-        idx = self.estimator_ids.index(id)
-
-        return self.estimators_[idx]
-    
-    def get_estimator_ids(self) -> list[str]:
-        """
-        Get the ids of all estimators in the forecaster.
-        
-        Returns
-        -------
-        estimator_ids : list[str]
-            List of estimator ids.
-        
-        """
-
-        return self.estimator_ids
-    
-    def remove_estimators(self, ids: str | list[str]) -> None:
-        """
-        Remove one or more estimators by their ids.
-        
-        Parameters
-        ----------
-        ids : str, list[str]
-            The ids of the estimators to remove.
-        
-        Returns
-        -------
-        None
-        
-        """
-
-        if isinstance(ids, str):
-            ids = [ids]
-        
-        missing_ids = [id for id in ids if id not in self.estimator_ids]
-        if missing_ids:
-            raise KeyError(
-                f"No estimator(s) with id '{missing_ids}'. "
-                f"Available estimators: {self.estimator_ids}"
-            )
-            
-        for id in ids:
-            idx = self.estimator_ids.index(id)
-            del self.estimators[idx]
-            del self.estimators_[idx]
-            del self.estimator_ids[idx]
-            del self.estimator_names_[idx]
-            del self.estimator_types[idx]
-            self.n_estimators -= 1
 
     def _preprocess_repr(self) -> tuple[list[str], str]:
         """
@@ -491,7 +382,7 @@ class ForecasterStats():
         """
 
         estimator_params, exog_names_in_ = self._preprocess_repr()
-        params_list = "\n    ".join(estimator_params)
+        estimator_params = "\n    ".join(estimator_params)
 
         info = (
             f"{'=' * len(type(self).__name__)} \n"
@@ -506,7 +397,7 @@ class ForecasterStats():
             f"Training range: {self.training_range_.to_list() if self.is_fitted else None} \n"
             f"Training index type: {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else None} \n"
             f"Training index frequency: {self.index_freq_ if self.is_fitted else None} \n"
-            f"Estimator parameters: \n    {params_list} \n"
+            f"Estimator parameters: \n    {estimator_params} \n"
             f"fit_kwargs: {self.fit_kwargs} \n"
             f"Creation date: {self.creation_date} \n"
             f"Last fit date: {self.fit_date} \n"
@@ -529,23 +420,9 @@ class ForecasterStats():
         estimator_params, exog_names_in_ = self._preprocess_repr()
         style, unique_id = get_style_repr_html(self.is_fitted)
 
-        # Build estimators list
-        estimators_html = "<ul>"
-        for est_id, est_name in zip(self.estimator_ids, self.estimator_names_):
-            if est_name is not None:
-                estimators_html += f"<li>{est_id}: {est_name}</li>"
-            else:
-                estimators_html += f"<li>{est_id}</li>"
-        estimators_html += "</ul>"
-
-        # Build parameters section
-        if len(estimator_params) == 1:
-            params_html = f"<ul><li>{estimator_params[0]}</li></ul>"
-        else:
-            params_html = "<ul>"
-            for param in estimator_params:
-                params_html += f"<li>{param}</li>"
-            params_html += "</ul>"
+        estimators_html, params_html = self._build_estimators_repr_html(
+            estimator_params=estimator_params
+        )
 
         content = f"""
         <div class="container-{unique_id}">
@@ -1569,47 +1446,6 @@ class ForecasterStats():
             raise ValueError("`method` must be either 'standard' or 'lutkepohl'")
 
         return estimator._forecaster.arima_res_.info_criteria(criteria=criteria, method=method)
-
-    def get_estimators_info(self) -> pd.DataFrame:
-        """
-        Get a summary DataFrame with information about all estimators in the 
-        forecaster.
-        
-        Returns
-        -------
-        info : pandas DataFrame
-            DataFrame with columns:
-            - id: Unique identifier for each estimator.
-            - name: Descriptive name (available after fitting).
-            - type: Full qualified type string.
-            - supports_exog: Whether the estimator supports exogenous variables.
-            - supports_interval: Whether the estimator supports prediction intervals.
-            - params: Dictionary of the estimator parameters.
-        
-        """
-
-        supports_exog = [
-            est_type in self.estimators_support_exog 
-            for est_type in self.estimator_types
-        ]
-        supports_interval = [
-            est_type in self.estimators_support_interval 
-            for est_type in self.estimator_types
-        ]
-        params = [
-            str(est_params) for est_params in self.estimator_params_.values()
-        ]
-
-        info = pd.DataFrame({
-            'id': self.estimator_ids,
-            'name': self.estimator_names_,
-            'type': self.estimator_types,
-            'supports_exog': supports_exog,
-            'supports_interval': supports_interval,
-            'params': params
-        })
-
-        return info
 
     def summary(self) -> None:
         """

--- a/skforecast/recursive/tests/tests_forecaster_stats/test_estimator_methods.py
+++ b/skforecast/recursive/tests/tests_forecaster_stats/test_estimator_methods.py
@@ -7,6 +7,7 @@ import pandas as pd
 from skforecast.stats import Sarimax, Arima, Ets
 from skforecast.recursive import ForecasterStats
 
+
 # Test get_estimator
 # ==============================================================================
 def test_get_estimator_raises_KeyError_when_id_not_found():
@@ -152,6 +153,9 @@ def test_remove_estimators_single_id():
         'skforecast.stats._sarimax.Sarimax', 'skforecast.stats._ets.Ets'
     ]
     assert forecaster.estimator_names_ == [None, None]
+    assert list(forecaster.estimator_params_.keys()) == [
+        'skforecast.Sarimax', 'skforecast.Ets'
+    ]
 
 
 def test_remove_estimators_multiple_ids_and_fitted():
@@ -174,6 +178,7 @@ def test_remove_estimators_multiple_ids_and_fitted():
     assert len(forecaster.estimators_) == 1
     assert forecaster.estimator_types == ['skforecast.stats._arima.Arima']
     assert forecaster.estimator_names_ == ['Arima(1,1,1)']
+    assert list(forecaster.estimator_params_.keys()) == ['skforecast.Arima']
 
 
 def test_remove_estimators_with_suffix_and_fitted():
@@ -195,6 +200,9 @@ def test_remove_estimators_with_suffix_and_fitted():
     ]
     assert forecaster.estimator_names_ == [
         'Sarimax(1,0,1)(0,0,0)[0]', 'Sarimax(3,0,1)(0,0,0)[0]'
+    ]
+    assert list(forecaster.estimator_params_.keys()) == [
+        'skforecast.Sarimax', 'skforecast.Sarimax_3'
     ]
 
 

--- a/skforecast/utils/__init__.py
+++ b/skforecast/utils/__init__.py
@@ -1,4 +1,6 @@
 from .utils import *
-from .utils import _build_predict_function
-from .utils import _get_estimator_categorical_set_params
-from .utils import _restore_estimator_categorical_set_params
+from .utils import (
+    _build_predict_function,
+    _get_estimator_categorical_set_params,
+    _restore_estimator_categorical_set_params
+)


### PR DESCRIPTION
- Extract multi-estimator logic into MultiEstimatorMixin to consolidate duplicated handling across forecasters.
- Update ForecasterStats to inherit from MultiEstimatorMixin instead of managing estimators inline.
- Fix remove_estimators not deleting the corresponding estimator params.
- Align utility functions and imports for consistency.
- Add tests covering MultiEstimatorMixin id generation, retrieval, and removal.