### PR TITLE
fix: treat TimeSeriesFold/OneStepAheadFold initial_train_size as immu…

### DIFF
--- a/skforecast/model_selection/_search.py
+++ b/skforecast/model_selection/_search.py
@@ -374,18 +374,12 @@ def _evaluate_grid_hyperparameters(
             suppress_warnings = suppress_warnings
         )
 
-        cv = deepcopy(cv)
         initial_train_size = date_to_index_position(
                                  index        = cv._extract_index(y), 
                                  date_input   = cv.initial_train_size, 
                                  method       = 'validation',
                                  date_literal = 'initial_train_size'
                              )
-        cv.set_params({
-            'window_size': forecaster_search.window_size,
-            'differentiation': forecaster_search.differentiation_max,
-            'verbose': verbose
-        })
 
     if not isinstance(metric, list):
         metric = [metric] 
@@ -688,18 +682,12 @@ def bayesian_search_forecaster(
             suppress_warnings = suppress_warnings
         )
 
-        cv = deepcopy(cv)
         initial_train_size = date_to_index_position(
                                  index        = cv._extract_index(y), 
                                  date_input   = cv.initial_train_size, 
                                  method       = 'validation',
                                  date_literal = 'initial_train_size'
                              )
-        cv.set_params({
-            'window_size': forecaster_search.window_size,
-            'differentiation': forecaster_search.differentiation_max,
-            'verbose': verbose
-        })
     
     if not isinstance(metric, list):
         metric = [metric]
@@ -1357,11 +1345,6 @@ def _evaluate_grid_hyperparameters_multiseries(
                                  method       = 'validation',
                                  date_literal = 'initial_train_size'
                              )
-        cv.set_params({
-            'window_size': forecaster_search.window_size,
-            'differentiation': forecaster_search.differentiation_max,
-            'verbose': verbose
-        })
     
     if aggregate_metric is None:
         aggregate_metric = ['weighted_average', 'average', 'pooling']
@@ -1745,18 +1728,12 @@ def bayesian_search_forecaster_multiseries(
             suppress_warnings = suppress_warnings
         )
 
-        cv = deepcopy(cv)
         initial_train_size = date_to_index_position(
                                  index        = cv._extract_index(series), 
                                  date_input   = cv.initial_train_size, 
                                  method       = 'validation',
                                  date_literal = 'initial_train_size'
                              )
-        cv.set_params({
-            'window_size': forecaster_search.window_size,
-            'differentiation': forecaster_search.differentiation_max,
-            'verbose': verbose
-        })
     
     if aggregate_metric is None:
         aggregate_metric = ['weighted_average', 'average', 'pooling']

--- a/skforecast/model_selection/_search.py
+++ b/skforecast/model_selection/_search.py
@@ -382,12 +382,11 @@ def _evaluate_grid_hyperparameters(
                                  date_literal = 'initial_train_size'
                              )
         cv.set_params({
-            'initial_train_size': initial_train_size,
             'window_size': forecaster_search.window_size,
             'differentiation': forecaster_search.differentiation_max,
             'verbose': verbose
         })
-   
+
     if not isinstance(metric, list):
         metric = [metric] 
     metric = [
@@ -438,7 +437,7 @@ def _evaluate_grid_hyperparameters(
                 sample_weight,
                 fit_kwargs
             ) = forecaster_search._train_test_split_one_step_ahead(
-                y=y, initial_train_size=cv.initial_train_size, exog=exog
+                y=y, initial_train_size=initial_train_size, exog=exog
             )
 
         if show_progress:
@@ -697,7 +696,6 @@ def bayesian_search_forecaster(
                                  date_literal = 'initial_train_size'
                              )
         cv.set_params({
-            'initial_train_size': initial_train_size,
             'window_size': forecaster_search.window_size,
             'differentiation': forecaster_search.differentiation_max,
             'verbose': verbose
@@ -814,7 +812,7 @@ def bayesian_search_forecaster(
                     sample_weight,
                     fit_kwargs
                 ) = forecaster_search._train_test_split_one_step_ahead(
-                    y=y, initial_train_size=cv.initial_train_size, exog=exog
+                    y=y, initial_train_size=initial_train_size, exog=exog
                 )
                 
                 _cached_split[lags_key] = (
@@ -1360,7 +1358,6 @@ def _evaluate_grid_hyperparameters_multiseries(
                                  date_literal = 'initial_train_size'
                              )
         cv.set_params({
-            'initial_train_size': initial_train_size,
             'window_size': forecaster_search.window_size,
             'differentiation': forecaster_search.differentiation_max,
             'verbose': verbose
@@ -1442,7 +1439,7 @@ def _evaluate_grid_hyperparameters_multiseries(
                 sample_weight,
                 fit_kwargs
             ) = forecaster_search._train_test_split_one_step_ahead(
-                series=series, exog=exog, initial_train_size=cv.initial_train_size
+                series=series, exog=exog, initial_train_size=initial_train_size
             )
 
         if show_progress:
@@ -1756,7 +1753,6 @@ def bayesian_search_forecaster_multiseries(
                                  date_literal = 'initial_train_size'
                              )
         cv.set_params({
-            'initial_train_size': initial_train_size,
             'window_size': forecaster_search.window_size,
             'differentiation': forecaster_search.differentiation_max,
             'verbose': verbose
@@ -1913,7 +1909,7 @@ def bayesian_search_forecaster_multiseries(
                     sample_weight,
                     fit_kwargs
                 ) = forecaster_search._train_test_split_one_step_ahead(
-                    series=series, exog=exog, initial_train_size=cv.initial_train_size,
+                    series=series, exog=exog, initial_train_size=initial_train_size,
                 )
                 _cached_split[lags_key] = (
                     X_train, y_train, X_test, y_test, X_train_encoding, X_test_encoding,

--- a/skforecast/model_selection/_split.py
+++ b/skforecast/model_selection/_split.py
@@ -440,12 +440,11 @@ class OneStepAheadFold(BaseFold):
 
         info = (
             f"OneStepAheadFold(\n"
-            f"    initial_train_size        = {self.initial_train_size},\n"
-            f"    initial_train_size_as_int = {self.initial_train_size_as_int},\n"
-            f"    window_size               = {self.window_size},\n"
-            f"    differentiation           = {self.differentiation},\n"
-            f"    return_all_indexes        = {self.return_all_indexes},\n"
-            f"    verbose                   = {self.verbose},\n"
+            f"    initial_train_size = {self.initial_train_size},\n"
+            f"    window_size        = {self.window_size},\n"
+            f"    differentiation    = {self.differentiation},\n"
+            f"    return_all_indexes = {self.return_all_indexes},\n"
+            f"    verbose            = {self.verbose},\n"
             f")"
         )
             
@@ -837,19 +836,18 @@ class TimeSeriesFold(BaseFold):
 
         info = (
             f"TimeSeriesFold(\n"
-            f"    initial_train_size        = {self.initial_train_size},\n"
-            f"    initial_train_size_as_int = {self.initial_train_size_as_int},\n"
-            f"    steps                     = {self.steps},\n"
-            f"    fold_stride               = {self.fold_stride},\n"
-            f"    window_size               = {self.window_size},\n"
-            f"    differentiation           = {self.differentiation},\n"
-            f"    refit                     = {self.refit},\n"
-            f"    fixed_train_size          = {self.fixed_train_size},\n"
-            f"    gap                       = {self.gap},\n"
-            f"    skip_folds                = {self.skip_folds},\n"
-            f"    allow_incomplete_fold     = {self.allow_incomplete_fold},\n"
-            f"    return_all_indexes        = {self.return_all_indexes},\n"
-            f"    verbose                   = {self.verbose},\n"
+            f"    initial_train_size    = {self.initial_train_size},\n"
+            f"    steps                 = {self.steps},\n"
+            f"    fold_stride           = {self.fold_stride},\n"
+            f"    window_size           = {self.window_size},\n"
+            f"    differentiation       = {self.differentiation},\n"
+            f"    refit                 = {self.refit},\n"
+            f"    fixed_train_size      = {self.fixed_train_size},\n"
+            f"    gap                   = {self.gap},\n"
+            f"    skip_folds            = {self.skip_folds},\n"
+            f"    allow_incomplete_fold = {self.allow_incomplete_fold},\n"
+            f"    return_all_indexes    = {self.return_all_indexes},\n"
+            f"    verbose               = {self.verbose},\n"
             f")"
         )
 
@@ -1153,10 +1151,11 @@ class TimeSeriesFold(BaseFold):
                 for fold in folds
             ]
 
-        self.initial_train_size_as_int = None if externally_fitted else initial_train_size_as_int
-
         if externally_fitted:
+            self.initial_train_size_as_int = None
             folds[0][5] = False
+        else:
+            self.initial_train_size_as_int = initial_train_size_as_int
 
         if as_pandas:
             if self.window_size is None:

--- a/skforecast/model_selection/_split.py
+++ b/skforecast/model_selection/_split.py
@@ -78,8 +78,12 @@ class BaseFold():
 
     Attributes
     ----------
-    initial_train_size : int
-        Number of observations used for initial training.
+    initial_train_size : int, str, pandas Timestamp
+        Number of observations used for initial training, or a date (string or pandas
+        Timestamp parseable by pandas) marking the last observation of the training set.
+    initial_train_size_as_int : int
+        Resolved integer position of `initial_train_size`, set when `split()` is called
+        (`None` when `initial_train_size` is `None`).
     window_size : int
         Number of observations needed to generate the autoregressive predictors.
     differentiation : int
@@ -124,11 +128,12 @@ class BaseFold():
             verbose               = verbose
         )
 
-        self.initial_train_size = initial_train_size
-        self.window_size        = window_size
-        self.differentiation    = differentiation
-        self.return_all_indexes = return_all_indexes
-        self.verbose            = verbose
+        self.initial_train_size        = initial_train_size
+        self.initial_train_size_as_int = None
+        self.window_size               = window_size
+        self.differentiation           = differentiation
+        self.return_all_indexes        = return_all_indexes
+        self.verbose                   = verbose
 
     def _validate_params(
         self,
@@ -392,18 +397,21 @@ class OneStepAheadFold(BaseFold):
 
     Attributes
     ----------
-    initial_train_size : int
-        Number of observations used for initial training.
+    initial_train_size : int, str, pandas Timestamp
+        Number of observations used for initial training, or a date (string or pandas
+        Timestamp parseable by pandas) marking the last observation of the training set.
+    initial_train_size_as_int : int
+        Resolved integer position of `initial_train_size`, set when `split()` is called.
     window_size : int
         Number of observations needed to generate the autoregressive predictors.
-    differentiation : int 
+    differentiation : int
         Number of observations to use for differentiation. This is used to extend the
         `last_window` as many observations as the differentiation order.
     return_all_indexes : bool
         Whether to return all indexes or only the start and end indexes of each fold.
     verbose : bool
         Whether to print information about generated folds.
-    
+
     """
 
     def __init__(
@@ -432,11 +440,12 @@ class OneStepAheadFold(BaseFold):
 
         info = (
             f"OneStepAheadFold(\n"
-            f"    initial_train_size = {self.initial_train_size},\n"
-            f"    window_size        = {self.window_size},\n"
-            f"    differentiation    = {self.differentiation},\n"
-            f"    return_all_indexes = {self.return_all_indexes},\n"
-            f"    verbose            = {self.verbose},\n"
+            f"    initial_train_size        = {self.initial_train_size},\n"
+            f"    initial_train_size_as_int = {self.initial_train_size_as_int},\n"
+            f"    window_size               = {self.window_size},\n"
+            f"    differentiation           = {self.differentiation},\n"
+            f"    return_all_indexes        = {self.return_all_indexes},\n"
+            f"    verbose                   = {self.verbose},\n"
             f")"
         )
             
@@ -456,6 +465,7 @@ class OneStepAheadFold(BaseFold):
                 <summary>General Information</summary>
                 <ul>
                     <li><strong>Initial train size:</strong> {self.initial_train_size}</li>
+                    <li><strong>Initial train size as int:</strong> {self.initial_train_size_as_int}</li>
                     <li><strong>Window size:</strong> {self.window_size}</li>
                     <li><strong>Differentiation:</strong> {self.differentiation}</li>
                     <li><strong>Return all indexes:</strong> {self.return_all_indexes}</li>
@@ -526,22 +536,25 @@ class OneStepAheadFold(BaseFold):
 
         index = self._extract_index(X)
 
-        self.initial_train_size = date_to_index_position(
-                                      index        = index, 
-                                      date_input   = self.initial_train_size, 
-                                      method       = 'validation',
-                                      date_literal = 'initial_train_size'
-                                  )
+        initial_train_size_as_int = date_to_index_position(
+                                        index        = index,
+                                        date_input   = self.initial_train_size,
+                                        method       = 'validation',
+                                        date_literal = 'initial_train_size'
+                                    )
+        self.initial_train_size_as_int = initial_train_size_as_int
 
         fold = [
             0,
-            [0, self.initial_train_size - 1],
-            [self.initial_train_size, len(X)],
+            [0, initial_train_size_as_int - 1],
+            [initial_train_size_as_int, len(X)],
             True
         ]
 
         if self.verbose:
-            self._print_info(index=index, fold=fold)
+            self._print_info(
+                index=index, fold=fold, initial_train_size_as_int=initial_train_size_as_int
+            )
 
         # NOTE: +1 to prevent iloc pandas from deleting the last observation
         if self.return_all_indexes:
@@ -588,7 +601,8 @@ class OneStepAheadFold(BaseFold):
     def _print_info(
         self,
         index: pd.Index,
-        fold: list[list[int]]
+        fold: list[list[int]],
+        initial_train_size_as_int: int
     ) -> None:
         """
         Print information about folds.
@@ -599,6 +613,8 @@ class OneStepAheadFold(BaseFold):
             Index of the time series data.
         fold : list
             A list of lists containing the indices (position) of the fold.
+        initial_train_size_as_int : int
+            Resolved integer position of `initial_train_size`.
 
         Returns
         -------
@@ -611,13 +627,13 @@ class OneStepAheadFold(BaseFold):
         else:
             differentiation = self.differentiation
 
-        initial_train_size = self.initial_train_size - differentiation
-        test_length = len(index) - (initial_train_size + differentiation)
+        initial_train_size_as_int = initial_train_size_as_int - differentiation
+        test_length = len(index) - (initial_train_size_as_int + differentiation)
 
         print("Information of folds")
         print("--------------------")
         print(
-            f"Number of observations in train: {initial_train_size}"
+            f"Number of observations in train: {initial_train_size_as_int}"
         )
         if self.differentiation is not None:
             print(
@@ -634,7 +650,7 @@ class OneStepAheadFold(BaseFold):
         test_end    = index[fold[2][-1] - 1]
         
         print(
-            f"Training : {training_start} -- {training_end} (n={initial_train_size})"
+            f"Training : {training_start} -- {training_end} (n={initial_train_size_as_int})"
         )
         print(
             f"Test     : {test_start} -- {test_end} (n={test_length})"
@@ -711,9 +727,13 @@ class TimeSeriesFold(BaseFold):
     steps : int
         Number of observations used to be predicted in each fold. This is also commonly
         referred to as the forecast horizon or test size.
-    initial_train_size : int
-        Number of observations used for initial training. If `None` or 0, the initial
-        forecaster is not trained in the first fold.
+    initial_train_size : int, str, pandas Timestamp
+        Number of observations used for initial training, or a date (string or pandas
+        Timestamp parseable by pandas) marking the last observation of the training set.
+        If `None` or 0, the initial forecaster is not trained in the first fold.
+    initial_train_size_as_int : int
+        Resolved integer position of `initial_train_size`, set when `split()` is called
+        (`None` when `initial_train_size` is `None`).
     fold_stride : int
         Number of observations that the start of the test set advances between
         consecutive folds.
@@ -817,18 +837,19 @@ class TimeSeriesFold(BaseFold):
 
         info = (
             f"TimeSeriesFold(\n"
-            f"    initial_train_size    = {self.initial_train_size},\n"
-            f"    steps                 = {self.steps},\n"
-            f"    fold_stride           = {self.fold_stride},\n"
-            f"    window_size           = {self.window_size},\n"
-            f"    differentiation       = {self.differentiation},\n"
-            f"    refit                 = {self.refit},\n"
-            f"    fixed_train_size      = {self.fixed_train_size},\n"
-            f"    gap                   = {self.gap},\n"
-            f"    skip_folds            = {self.skip_folds},\n"
-            f"    allow_incomplete_fold = {self.allow_incomplete_fold},\n"
-            f"    return_all_indexes    = {self.return_all_indexes},\n"
-            f"    verbose               = {self.verbose},\n"
+            f"    initial_train_size        = {self.initial_train_size},\n"
+            f"    initial_train_size_as_int = {self.initial_train_size_as_int},\n"
+            f"    steps                     = {self.steps},\n"
+            f"    fold_stride               = {self.fold_stride},\n"
+            f"    window_size               = {self.window_size},\n"
+            f"    differentiation           = {self.differentiation},\n"
+            f"    refit                     = {self.refit},\n"
+            f"    fixed_train_size          = {self.fixed_train_size},\n"
+            f"    gap                       = {self.gap},\n"
+            f"    skip_folds                = {self.skip_folds},\n"
+            f"    allow_incomplete_fold     = {self.allow_incomplete_fold},\n"
+            f"    return_all_indexes        = {self.return_all_indexes},\n"
+            f"    verbose                   = {self.verbose},\n"
             f")"
         )
 
@@ -848,6 +869,7 @@ class TimeSeriesFold(BaseFold):
                 <summary>General Information</summary>
                 <ul>
                     <li><strong>Initial train size:</strong> {self.initial_train_size}</li>
+                    <li><strong>Initial train size as int:</strong> {self.initial_train_size_as_int}</li>
                     <li><strong>Steps:</strong> {self.steps}</li>
                     <li><strong>Fold stride:</strong> {self.fold_stride}</li>
                     <li><strong>Overlapping folds:</strong> {self.overlapping_folds}</li>
@@ -967,7 +989,7 @@ class TimeSeriesFold(BaseFold):
                     "Set `refit` to `False` if you want to use `initial_train_size = None`."
                 )
             externally_fitted = True
-            self.initial_train_size = self.window_size  # Reset to None later
+            initial_train_size = self.window_size
         else:
             if self.window_size is None:
                 warnings.warn(
@@ -975,22 +997,23 @@ class TimeSeriesFold(BaseFold):
                     IgnoredArgumentWarning
                 )
             externally_fitted = False
+            initial_train_size = self.initial_train_size
 
         index = self._extract_index(X)
         idx = range(len(index))
         folds = []
         i = 0
 
-        self.initial_train_size = date_to_index_position(
-                                      index        = index, 
-                                      date_input   = self.initial_train_size, 
-                                      method       = 'validation',
-                                      date_literal = 'initial_train_size'
-                                  )
-        
+        initial_train_size_as_int = date_to_index_position(
+                                        index        = index,
+                                        date_input   = initial_train_size,
+                                        method       = 'validation',
+                                        date_literal = 'initial_train_size'
+                                    )
+
         if window_size_as_date_offset:
-            if self.initial_train_size is not None:
-                if self.initial_train_size < self.window_size:
+            if initial_train_size_as_int is not None:
+                if initial_train_size_as_int < self.window_size:
                     raise ValueError(
                         f"If `initial_train_size` is an integer, it must be greater than "
                         f"the `window_size` of the forecaster ({self.window_size}) "
@@ -1000,43 +1023,43 @@ class TimeSeriesFold(BaseFold):
 
         if self.allow_incomplete_fold:
             # At least one observation after the gap to allow incomplete fold
-            if len(index) <= self.initial_train_size + self.gap:
+            if len(index) <= initial_train_size_as_int + self.gap:
                 raise ValueError(
                     f"The time series must have more than `initial_train_size + gap` "
                     f"observations to create at least one fold.\n"
                     f"    Time series length: {len(index)}\n"
-                    f"    Required > {self.initial_train_size + self.gap}\n"
-                    f"    initial_train_size: {self.initial_train_size}\n"
+                    f"    Required > {initial_train_size_as_int + self.gap}\n"
+                    f"    initial_train_size: {initial_train_size_as_int}\n"
                     f"    gap: {self.gap}\n"
                 )
         else:
             # At least one complete fold
-            if len(index) < self.initial_train_size + self.gap + self.steps:
+            if len(index) < initial_train_size_as_int + self.gap + self.steps:
                 raise ValueError(
                     f"The time series must have at least `initial_train_size + gap + steps` "
                     f"observations to create a minimum of one complete fold "
                     f"(allow_incomplete_fold=False).\n"
                     f"    Time series length: {len(index)}\n"
-                    f"    Required >= {self.initial_train_size + self.gap + self.steps}\n"
-                    f"    initial_train_size: {self.initial_train_size}\n"
+                    f"    Required >= {initial_train_size_as_int + self.gap + self.steps}\n"
+                    f"    initial_train_size: {initial_train_size_as_int}\n"
                     f"    gap: {self.gap}\n"
                     f"    steps: {self.steps}\n"
                 )
 
-        while self.initial_train_size + (i * self.fold_stride) + self.gap < len(index):
+        while initial_train_size_as_int + (i * self.fold_stride) + self.gap < len(index):
 
             if self.refit:
-                # NOTE: If `fixed_train_size` the train size doesn't increase but 
-                # moves by `fold_stride` positions in each iteration. If `False`, 
+                # NOTE: If `fixed_train_size` the train size doesn't increase but
+                # moves by `fold_stride` positions in each iteration. If `False`,
                 # the train size increases by `fold_stride` in each iteration.
                 train_iloc_start = i * (self.fold_stride) if self.fixed_train_size else 0
-                train_iloc_end = self.initial_train_size + i * (self.fold_stride)
+                train_iloc_end = initial_train_size_as_int + i * (self.fold_stride)
                 test_iloc_start = train_iloc_end
             else:
                 # NOTE: The train size doesn't increase and doesn't move.
                 train_iloc_start = 0
-                train_iloc_end = self.initial_train_size
-                test_iloc_start = self.initial_train_size + i * (self.fold_stride)
+                train_iloc_end = initial_train_size_as_int
+                test_iloc_start = initial_train_size_as_int + i * (self.fold_stride)
             
             if self.window_size is not None:
                 # NOTE: When window_size > test_iloc_start (e.g. a large
@@ -1103,11 +1126,12 @@ class TimeSeriesFold(BaseFold):
         
         if self.verbose:
             self._print_info(
-                index              = index,
-                folds              = folds,
-                externally_fitted  = externally_fitted,
-                n_removed_folds    = n_removed_folds,
-                index_to_skip      = index_to_skip
+                index                     = index,
+                folds                     = folds,
+                externally_fitted         = externally_fitted,
+                n_removed_folds           = n_removed_folds,
+                index_to_skip             = index_to_skip,
+                initial_train_size_as_int = initial_train_size_as_int
             )
 
         folds = [fold for i, fold in enumerate(folds) if i not in index_to_skip]
@@ -1129,8 +1153,9 @@ class TimeSeriesFold(BaseFold):
                 for fold in folds
             ]
 
+        self.initial_train_size_as_int = None if externally_fitted else initial_train_size_as_int
+
         if externally_fitted:
-            self.initial_train_size = None
             folds[0][5] = False
 
         if as_pandas:
@@ -1175,7 +1200,8 @@ class TimeSeriesFold(BaseFold):
         folds: list[list[int]],
         externally_fitted: bool,
         n_removed_folds: int,
-        index_to_skip: list[int]
+        index_to_skip: list[int],
+        initial_train_size_as_int: int
     ) -> None:
         """
         Print information about folds.
@@ -1192,11 +1218,13 @@ class TimeSeriesFold(BaseFold):
             Number of folds removed.
         index_to_skip : list
             Indexes of folds to skip.
+        initial_train_size_as_int : int
+            Resolved integer position of `initial_train_size`.
 
         Returns
         -------
         None
-        
+
         """
 
         print("Information of folds")
@@ -1210,12 +1238,12 @@ class TimeSeriesFold(BaseFold):
             if self.differentiation is None:
                 print(
                     f"Number of observations used for initial training: "
-                    f"{self.initial_train_size}"
+                    f"{initial_train_size_as_int}"
                 )
             else:
                 print(
                     f"Number of observations used for initial training: "
-                    f"{self.initial_train_size - self.differentiation}"
+                    f"{initial_train_size_as_int - self.differentiation}"
                 )
                 print(
                     f"    First {self.differentiation} observation/s in training sets "
@@ -1223,7 +1251,7 @@ class TimeSeriesFold(BaseFold):
                 )
         print(
             f"Number of observations used for backtesting: "
-            f"{len(index) - self.initial_train_size}"
+            f"{len(index) - initial_train_size_as_int}"
         )
         print(f"    Number of folds: {len(folds)}")
         print(

--- a/skforecast/model_selection/_validation.py
+++ b/skforecast/model_selection/_validation.py
@@ -499,7 +499,7 @@ def _backtesting_forecaster(
         forecaster._probabilistic_mode = 'no_binned'
 
     folds = cv.split(X=y, as_pandas=False)
-    initial_train_size = cv.initial_train_size
+    initial_train_size = cv.initial_train_size_as_int
     window_size = cv.window_size
     gap = cv.gap
 
@@ -1255,7 +1255,7 @@ def _backtesting_forecaster_multiseries(
 
     folds = cv.split(X=series, as_pandas=False)
     span_index = cv._extract_index(X=series)
-    initial_train_size = cv.initial_train_size
+    initial_train_size = cv.initial_train_size_as_int
     gap = cv.gap
 
     # Save out-of-sample residuals before any fit() call. Since fit() resets
@@ -1953,7 +1953,7 @@ def _backtesting_stats(
         ]
     
     folds = cv.split(X=y, as_pandas=False)
-    initial_train_size = cv.initial_train_size
+    initial_train_size = cv.initial_train_size_as_int
     steps = cv.steps
     gap = cv.gap
 

--- a/skforecast/model_selection/tests/tests_search/test_grid_search_forecaster.py
+++ b/skforecast/model_selection/tests/tests_search/test_grid_search_forecaster.py
@@ -168,3 +168,52 @@ def test_grid_search_forecaster_equivalence_backtesting_one_step_ahead(
     )
 
     pd.testing.assert_frame_equal(results_backtesting, results_one_step_ahead)
+
+
+@pytest.mark.parametrize("forecaster", forecasters)
+def test_grid_search_forecaster_one_step_ahead_date_initial_train_size_equivalence(
+    forecaster,
+):
+    """
+    Test that grid_search_forecaster with OneStepAheadFold returns identical results
+    whether `initial_train_size` is given as an integer or as the equivalent date.
+    """
+    metrics = ["mean_absolute_error", "mean_squared_error"]
+    n_validation = 12
+    initial_train_size_int = len(y) - n_validation  # 38
+    lags_grid = [2, 4]
+    param_grid = {"alpha": [0.01, 0.1, 1]}
+
+    # Datetime-indexed copy so a date `initial_train_size` is valid. Position 37
+    # (the 38th observation) is 2020-02-07; `date_to_index_position` resolves it to 38.
+    y_datetime = y.copy()
+    y_datetime.index = pd.date_range(start='2020-01-01', periods=len(y), freq='D')
+
+    cv_int = OneStepAheadFold(initial_train_size=initial_train_size_int)
+    cv_date = OneStepAheadFold(initial_train_size="2020-02-07")
+
+    results_int = grid_search_forecaster(
+        forecaster=forecaster,
+        y=y_datetime,
+        cv=cv_int,
+        lags_grid=lags_grid,
+        param_grid=param_grid,
+        metric=metrics,
+        return_best=False,
+        verbose=False,
+    )
+    results_date = grid_search_forecaster(
+        forecaster=forecaster,
+        y=y_datetime,
+        cv=cv_date,
+        lags_grid=lags_grid,
+        param_grid=param_grid,
+        metric=metrics,
+        return_best=False,
+        verbose=False,
+    )
+
+    pd.testing.assert_frame_equal(results_int, results_date)
+    # `initial_train_size` must remain the raw user input on the (deep-copied) cv objects.
+    assert cv_int.initial_train_size == initial_train_size_int
+    assert cv_date.initial_train_size == "2020-02-07"

--- a/skforecast/model_selection/tests/tests_split/test_onestepaheadfold.py
+++ b/skforecast/model_selection/tests/tests_split/test_onestepaheadfold.py
@@ -215,3 +215,7 @@ def test_OneStepAhead_split_int_and_date_initial_train_size(capfd, initial_train
 
     assert out == expected_out
     assert folds == expected
+    # `initial_train_size` is immutable user input; the resolved integer position
+    # is stored in `initial_train_size_as_int` (split() must not mutate the input).
+    assert cv.initial_train_size == initial_train_size
+    assert cv.initial_train_size_as_int == 70

--- a/skforecast/model_selection/tests/tests_split/test_timeseriesfold.py
+++ b/skforecast/model_selection/tests/tests_split/test_timeseriesfold.py
@@ -434,6 +434,8 @@ def test_TimeSeriesFold_split_no_refit_initial_train_size_None_gap(capfd, return
 
     assert out == expected_out
     assert folds == expected
+    assert cv.initial_train_size is None
+    assert cv.initial_train_size_as_int is None
 
 
 @pytest.mark.parametrize("return_all_indexes, expected",
@@ -1346,8 +1348,12 @@ def test_TimeSeriesFold_split_int_and_date_initial_train_size(capfd, initial_tra
             gap                   = 5,
         )
     folds = cv.split(X=y)
-                    
+
     out, _ = capfd.readouterr()
+    # `initial_train_size` is immutable user input; the resolved integer position
+    # is stored in `initial_train_size_as_int` (split() must not mutate the input).
+    assert cv.initial_train_size == initial_train_size
+    assert cv.initial_train_size_as_int == 70
     
     expected_out = (
         "Information of folds\n"
@@ -1375,7 +1381,44 @@ def test_TimeSeriesFold_split_int_and_date_initial_train_size(capfd, initial_tra
 
     assert out == expected_out
     assert folds == expected
-    
+
+
+def test_TimeSeriesFold_split_does_not_mutate_initial_train_size_and_reresolves_date():
+    """
+    Test that split() never mutates `initial_train_size` (immutable user input) and
+    re-resolves a date `initial_train_size` against the current index each time it is
+    called, instead of reusing a stale integer from a previous split on a different
+    index.
+    """
+    initial_train_size = "2022-03-11"
+    cv = TimeSeriesFold(
+             steps              = 7,
+             initial_train_size = initial_train_size,
+             window_size        = 10,
+             gap                = 5,
+             verbose            = False,
+         )
+
+    # Attribute exists and is None before split() is called.
+    assert cv.initial_train_size_as_int is None
+
+    # First index: "2022-03-11" is the 70th observation (position 69 + 1).
+    y = pd.Series(np.arange(100))
+    y.index = pd.date_range(start='2022-01-01', periods=100, freq='D')
+    cv.split(X=y)
+
+    assert cv.initial_train_size == initial_train_size
+    assert cv.initial_train_size_as_int == 70
+
+    # Second index starting earlier: the same date resolves to a later position
+    # (position 79 + 1), proving the integer is re-resolved, not reused.
+    y_shifted = pd.Series(np.arange(120))
+    y_shifted.index = pd.date_range(start='2021-12-22', periods=120, freq='D')
+    cv.split(X=y_shifted)
+
+    assert cv.initial_train_size == initial_train_size
+    assert cv.initial_train_size_as_int == 80
+
 
 @pytest.mark.parametrize("return_all_indexes, expected",
                          [(True, [[0, range(0, 70), range(66, 70), range(70, 81), range(70, 81), True],


### PR DESCRIPTION
TimeSeriesFold.split() and OneStepAheadFold.split() mutated the user-supplied initial_train_size. When a date was passed, split() resolved it to an integer index position and wrote it back onto self.initial_train_size, destroying the original input. Because cv objects are reused across folds and searches, a second split() on a different index reused the stale integer instead of re-resolving the date, producing incorrect folds.

A new attribute initial_train_size_as_int is added to BaseFold (inherited by both TimeSeriesFold and OneStepAheadFold) to hold the date-to-integer resolution, so the user's original initial_train_size is never overwritten, avoiding the corruption. 

This fix require to change the current use of `initial_train_size`in the whole database: Impacted sites

_split.py: core fix in both fold classes (init, split, _print_info, reprs, docstrings).
_validation.py: 3 post-split reads in the backtesting functions switched to initial_train_size_as_int.
_search.py: 4 OneStepAheadFold branches no longer round-trip the value through set_params; the resolved integer is passed directly to the train/test split.
_utils.py and the pre-split checks in _validation.py were verified already correct and left unchanged.

Unit test updated and extended to check this new funtionality