### PR TITLE
Fix: Training index frequency not showing in HTML representation

### DIFF
--- a/skforecast/deep_learning/_forecaster_rnn.py
+++ b/skforecast/deep_learning/_forecaster_rnn.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import sys
+import html
 import warnings
 from copy import deepcopy
 from typing import Any
@@ -563,7 +564,7 @@ class ForecasterRnn(ForecasterBase):
                     <li><strong>Target series (levels):</strong> {self.levels}</li>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/deep_learning/_forecaster_rnn.py
+++ b/skforecast/deep_learning/_forecaster_rnn.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import sys
-import html
 import warnings
 from copy import deepcopy
 from typing import Any
@@ -564,7 +563,7 @@ class ForecasterRnn(ForecasterBase):
                     <li><strong>Target series (levels):</strong> {self.levels}</li>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/direct/_forecaster_direct.py
+++ b/skforecast/direct/_forecaster_direct.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Callable
 import warnings
 import sys
-import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -778,7 +777,7 @@ class ForecasterDirect(ForecasterBase):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/direct/_forecaster_direct.py
+++ b/skforecast/direct/_forecaster_direct.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Callable
 import warnings
 import sys
+import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -777,7 +778,7 @@ class ForecasterDirect(ForecasterBase):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/direct/_forecaster_direct_multivariate.py
+++ b/skforecast/direct/_forecaster_direct_multivariate.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Callable, Any
 import warnings
 import sys
-import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -742,7 +741,7 @@ class ForecasterDirectMultiVariate(ForecasterBase):
                     <li><strong>Multivariate series:</strong> {series_names_in_}</li>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/direct/_forecaster_direct_multivariate.py
+++ b/skforecast/direct/_forecaster_direct_multivariate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Callable, Any
 import warnings
 import sys
+import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -741,7 +742,7 @@ class ForecasterDirectMultiVariate(ForecasterBase):
                     <li><strong>Multivariate series:</strong> {series_names_in_}</li>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/foundation/_forecaster_foundation.py
+++ b/skforecast/foundation/_forecaster_foundation.py
@@ -580,7 +580,7 @@ class ForecasterFoundation:
                 <ul>
                     <li><strong>Context range:</strong> {context_range_html}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/foundation/_forecaster_foundation.py
+++ b/skforecast/foundation/_forecaster_foundation.py
@@ -580,7 +580,7 @@ class ForecasterFoundation:
                 <ul>
                     <li><strong>Context range:</strong> {context_range_html}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_equivalent_date.py
+++ b/skforecast/recursive/_forecaster_equivalent_date.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Callable, Any
 import warnings
 import sys
-import html
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import NotFittedError
@@ -320,7 +319,7 @@ class ForecasterEquivalentDate():
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <p>

--- a/skforecast/recursive/_forecaster_equivalent_date.py
+++ b/skforecast/recursive/_forecaster_equivalent_date.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Callable, Any
 import warnings
 import sys
+import html
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import NotFittedError
@@ -319,7 +320,7 @@ class ForecasterEquivalentDate():
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <p>

--- a/skforecast/recursive/_forecaster_recursive.py
+++ b/skforecast/recursive/_forecaster_recursive.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Callable
 import warnings
 import sys
-import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -576,7 +575,7 @@ class ForecasterRecursive(ForecasterBase):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_recursive.py
+++ b/skforecast/recursive/_forecaster_recursive.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Callable
 import warnings
 import sys
+import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -575,7 +576,7 @@ class ForecasterRecursive(ForecasterBase):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_recursive_classifier.py
+++ b/skforecast/recursive/_forecaster_recursive_classifier.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Callable, Any
 import warnings
 import sys
-import html
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import NotFittedError
@@ -539,7 +538,7 @@ class ForecasterRecursiveClassifier(ForecasterBase):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_recursive_classifier.py
+++ b/skforecast/recursive/_forecaster_recursive_classifier.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Callable, Any
 import warnings
 import sys
+import html
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import NotFittedError
@@ -538,7 +539,7 @@ class ForecasterRecursiveClassifier(ForecasterBase):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_recursive_multiseries.py
+++ b/skforecast/recursive/_forecaster_recursive_multiseries.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Callable
 import warnings
 import sys
-import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -791,7 +790,7 @@ class ForecasterRecursiveMultiSeries(ForecasterBase):
                     <li><strong>Series names (levels):</strong> {series_names_in_}</li>
                     <li><strong>Training range:</strong> {training_range_}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_recursive_multiseries.py
+++ b/skforecast/recursive/_forecaster_recursive_multiseries.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Callable
 import warnings
 import sys
+import html
 import numpy as np
 import pandas as pd
 import inspect
@@ -790,7 +791,7 @@ class ForecasterRecursiveMultiSeries(ForecasterBase):
                     <li><strong>Series names (levels):</strong> {series_names_in_}</li>
                     <li><strong>Training range:</strong> {training_range_}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_stats.py
+++ b/skforecast/recursive/_forecaster_stats.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Any
 import warnings
 import sys
-import html
 from copy import copy
 import textwrap
 import numpy as np
@@ -463,7 +462,7 @@ class ForecasterStats(MultiEstimatorMixin):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {self.index_freq_.freqstr if hasattr(self.index_freq_, 'freqstr') else str(self.index_freq_) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>

--- a/skforecast/recursive/_forecaster_stats.py
+++ b/skforecast/recursive/_forecaster_stats.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 import warnings
 import sys
+import html
 from copy import copy
 import textwrap
 import numpy as np
@@ -462,7 +463,7 @@ class ForecasterStats(MultiEstimatorMixin):
                 <ul>
                     <li><strong>Training range:</strong> {self.training_range_.to_list() if self.is_fitted else 'Not fitted'}</li>
                     <li><strong>Training index type:</strong> {str(self.index_type_).split('.')[-1][:-2] if self.is_fitted else 'Not fitted'}</li>
-                    <li><strong>Training index frequency:</strong> {self.index_freq_ if self.is_fitted else 'Not fitted'}</li>
+                    <li><strong>Training index frequency:</strong> {html.escape(str(self.index_freq_)) if self.is_fitted else 'Not fitted'}</li>
                 </ul>
             </details>
             <details>


### PR DESCRIPTION
## Problem

When displaying a fitted forecaster in a Jupyter notebook, the "Training index frequency" field appeared blank. The root cause was that pandas frequency objects (e.g. daily, hourly, monthly) produce strings like <Day> or <Hour> when converted to text. Because the HTML representation was inserting these values directly into the HTML, the browser interpreted them as unknown HTML tags and silently discarded them, leaving the field empty.

## Fix

Instead of converting the frequency object to its default string form, the fix reads the compact alias that pandas already provides for this purpose (e.g. D, h, ME, QE-DEC). These aliases contain no special characters, so they render correctly in HTML without any escaping. For integer-indexed series (RangeIndex), the step value is used directly, which is also safe.

## Scope

The fix is applied consistently across all forecaster classes: ForecasterRecursive, ForecasterRecursiveMultiSeries, ForecasterRecursiveClassifier, ForecasterStats, ForecasterEquivalentDate, ForecasterDirect, ForecasterDirectMultiVariate, ForecasterRnn, and ForecasterFoundation. No new dependencies are introduced.