### PR TITLE
Add scikit-learn compatibility checks and related utilities

### DIFF
--- a/dev/check_sklearn_1_9/_sklearn_compat_checks.py
+++ b/dev/check_sklearn_1_9/_sklearn_compat_checks.py
@@ -1,0 +1,294 @@
+"""
+Individual scikit-learn compatibility checks and the check registry.
+
+Two groups of checks are defined:
+
+- ML forecasters: exercise every skforecast machine learning forecaster
+  end to end (fit / predict, and probabilistic prediction where available).
+- scikit-learn API touch points: exercise the specific scikit-learn features
+  skforecast relies on and that are most exposed to upstream changes
+  (cloning, pipelines, column transformers, feature selection, estimator tags,
+  and the hyperparameter search workflow).
+
+The ``CHECKS`` mapping at the bottom is consumed by the entry point.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from _sklearn_compat_data import (
+    make_class_series,
+    make_exog,
+    make_multi_series,
+    make_series,
+)
+
+
+# ----------------------------------------------------------------------------
+# Individual checks: ML forecasters
+# ----------------------------------------------------------------------------
+def check_recursive_forecaster() -> None:
+    """ForecasterRecursive: fit, predict and probabilistic prediction."""
+
+    from sklearn.ensemble import RandomForestRegressor
+
+    from skforecast.preprocessing import RollingFeatures
+    from skforecast.recursive import ForecasterRecursive
+
+    y = make_series()
+    exog = make_exog()
+    exog_train = exog.loc[y.index]
+    exog_future = exog.iloc[len(y):]
+    forecaster = ForecasterRecursive(
+        estimator=RandomForestRegressor(n_estimators=10, random_state=123),
+        lags=7,
+        window_features=RollingFeatures(stats=["mean", "std"], window_sizes=7),
+    )
+    forecaster.fit(y=y, exog=exog_train, store_in_sample_residuals=True)
+    forecaster.predict(steps=5, exog=exog_future)
+    forecaster.predict_interval(
+        steps=5,
+        exog=exog_future,
+        interval=[0.1, 0.9],
+        method="conformal",
+    )
+
+
+def check_direct_forecaster() -> None:
+    from sklearn.linear_model import Ridge
+    from sklearn.preprocessing import StandardScaler
+
+    from skforecast.direct import ForecasterDirect
+
+    y = make_series()
+    forecaster = ForecasterDirect(
+        estimator=Ridge(random_state=123),
+        lags=7,
+        steps=5,
+        transformer_y=StandardScaler(),
+    )
+    forecaster.fit(y=y)
+    forecaster.predict(steps=5)
+
+
+def check_multiseries_forecaster() -> None:
+    """ForecasterRecursiveMultiSeries: global model over several series."""
+
+    from sklearn.linear_model import LinearRegression
+    from sklearn.preprocessing import StandardScaler
+
+    from skforecast.recursive import ForecasterRecursiveMultiSeries
+
+    series = make_multi_series()
+    forecaster = ForecasterRecursiveMultiSeries(
+        estimator=LinearRegression(),
+        lags=7,
+        encoding="ordinal",
+        transformer_series=StandardScaler(),
+    )
+    forecaster.fit(series=series)
+    forecaster.predict(steps=5)
+    forecaster.predict(steps=5, levels=["series_1", "series_2"])
+
+
+def check_direct_multivariate_forecaster() -> None:
+    """ForecasterDirectMultiVariate: several series used as predictors."""
+
+    from sklearn.linear_model import Ridge
+    from sklearn.preprocessing import StandardScaler
+
+    from skforecast.direct import ForecasterDirectMultiVariate
+
+    series = make_multi_series()
+    forecaster = ForecasterDirectMultiVariate(
+        estimator=Ridge(random_state=123),
+        level="series_1",
+        steps=5,
+        lags=7,
+        transformer_series=StandardScaler(),
+    )
+    forecaster.fit(series=series)
+    forecaster.predict(steps=5)
+
+
+def check_recursive_classifier_forecaster() -> None:
+    """ForecasterRecursiveClassifier: classification-based forecasting."""
+
+    from sklearn.linear_model import LogisticRegression
+
+    from skforecast.preprocessing import RollingFeaturesClassification
+    from skforecast.recursive import ForecasterRecursiveClassifier
+
+    y = make_class_series()
+    forecaster = ForecasterRecursiveClassifier(
+        estimator=LogisticRegression(max_iter=1000),
+        lags=7,
+        window_features=RollingFeaturesClassification(
+            stats=["proportion"], window_sizes=7
+        ),
+    )
+    forecaster.fit(y=y)
+    forecaster.predict(steps=5)
+    forecaster.predict_proba(steps=5)
+
+
+def check_categorical_features() -> None:
+    """Built-in categorical handling relies on sklearn's OrdinalEncoder."""
+
+    from sklearn.ensemble import HistGradientBoostingRegressor
+
+    from skforecast.recursive import ForecasterRecursive
+
+    y = make_series()
+    exog = make_exog()
+    exog_train = exog.loc[y.index]
+    exog_future = exog.iloc[len(y):]
+    forecaster = ForecasterRecursive(
+        estimator=HistGradientBoostingRegressor(random_state=123),
+        lags=7,
+        categorical_features="auto",
+    )
+    forecaster.fit(y=y, exog=exog_train)
+    forecaster.predict(steps=5, exog=exog_future)
+
+
+# ----------------------------------------------------------------------------
+# Individual checks: scikit-learn API touch points and workflows
+# ----------------------------------------------------------------------------
+def check_pipeline_and_column_transformer() -> None:
+    from sklearn.compose import make_column_transformer
+    from sklearn.linear_model import LinearRegression
+    from sklearn.pipeline import make_pipeline
+    from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+    from skforecast.recursive import ForecasterRecursive
+
+    y = make_series()
+    exog = make_exog()
+    exog_train = exog.loc[y.index]
+    exog_future = exog.iloc[len(y):]
+
+    transformer_exog = make_column_transformer(
+        (StandardScaler(), ["exog_num"]),
+        (OneHotEncoder(sparse_output=False, handle_unknown="ignore"), ["exog_cat"]),
+        remainder="passthrough",
+        verbose_feature_names_out=False,
+    ).set_output(transform="pandas")
+
+    forecaster = ForecasterRecursive(
+        estimator=make_pipeline(StandardScaler(), LinearRegression()),
+        lags=7,
+        transformer_exog=transformer_exog,
+    )
+    forecaster.fit(y=y, exog=exog_train)
+    forecaster.predict(steps=5, exog=exog_future)
+
+
+def check_clone_and_get_set_params() -> None:
+    from sklearn.base import clone
+    from sklearn.linear_model import Ridge
+
+    from skforecast.recursive import ForecasterRecursive
+
+    forecaster = ForecasterRecursive(estimator=Ridge(), lags=7)
+    cloned = clone(forecaster.estimator)
+    cloned.get_params()
+    cloned.set_params(alpha=0.5)
+
+
+def check_backtesting() -> None:
+    from sklearn.linear_model import LinearRegression
+
+    from skforecast.model_selection import TimeSeriesFold, backtesting_forecaster
+    from skforecast.recursive import ForecasterRecursive
+
+    y = make_series()
+    forecaster = ForecasterRecursive(estimator=LinearRegression(), lags=7)
+    cv = TimeSeriesFold(steps=5, initial_train_size=len(y) - 20, refit=False)
+    backtesting_forecaster(
+        forecaster=forecaster,
+        y=y,
+        cv=cv,
+        metric="mean_absolute_error",
+        verbose=False,
+        show_progress=False,
+    )
+
+
+def check_grid_search() -> None:
+    from sklearn.ensemble import RandomForestRegressor
+
+    from skforecast.model_selection import TimeSeriesFold, grid_search_forecaster
+    from skforecast.recursive import ForecasterRecursive
+
+    y = make_series()
+    forecaster = ForecasterRecursive(
+        estimator=RandomForestRegressor(random_state=123),
+        lags=7,
+    )
+    cv = TimeSeriesFold(steps=5, initial_train_size=len(y) - 20, refit=False)
+    grid_search_forecaster(
+        forecaster=forecaster,
+        y=y,
+        cv=cv,
+        param_grid={"n_estimators": [5, 10], "max_depth": [3, 5]},
+        lags_grid=[3, 7],
+        metric="mean_absolute_error",
+        return_best=True,
+        verbose=False,
+        show_progress=False,
+    )
+
+
+def check_feature_selection() -> None:
+    from sklearn.feature_selection import RFECV
+    from sklearn.linear_model import LinearRegression
+
+    from skforecast.feature_selection import select_features
+    from skforecast.recursive import ForecasterRecursive
+
+    y = make_series()
+    forecaster = ForecasterRecursive(estimator=LinearRegression(), lags=7)
+    select_features(
+        forecaster=forecaster,
+        selector=RFECV(estimator=LinearRegression(), step=1, cv=2),
+        y=y,
+        verbose=False,
+    )
+
+
+def check_estimator_tags() -> None:
+    """Estimator tags API changed across recent scikit-learn releases."""
+
+    from sklearn.linear_model import LinearRegression
+
+    estimator = LinearRegression()
+    # ``__sklearn_tags__`` (1.6+) or the legacy ``_get_tags`` fallback.
+    if hasattr(estimator, "__sklearn_tags__"):
+        estimator.__sklearn_tags__()
+    elif hasattr(estimator, "_get_tags"):
+        estimator._get_tags()
+    else:  # pragma: no cover - defensive
+        raise AttributeError(
+            "No estimator tags API found on scikit-learn estimator."
+        )
+
+
+# Registry consumed by the entry point. Order is preserved in the report.
+CHECKS: dict[str, Callable[[], None]] = {
+    # ML forecasters
+    "ForecasterRecursive fit/predict/interval": check_recursive_forecaster,
+    "ForecasterDirect + transformer_y": check_direct_forecaster,
+    "ForecasterRecursiveMultiSeries": check_multiseries_forecaster,
+    "ForecasterDirectMultiVariate": check_direct_multivariate_forecaster,
+    "ForecasterRecursiveClassifier": check_recursive_classifier_forecaster,
+    "categorical_features (OrdinalEncoder)": check_categorical_features,
+    # scikit-learn API touch points and workflows
+    "Pipeline + ColumnTransformer exog": check_pipeline_and_column_transformer,
+    "clone / get_params / set_params": check_clone_and_get_set_params,
+    "backtesting_forecaster": check_backtesting,
+    "grid_search_forecaster": check_grid_search,
+    "select_features (RFECV)": check_feature_selection,
+    "estimator tags API": check_estimator_tags,
+}

--- a/dev/check_sklearn_1_9/_sklearn_compat_data.py
+++ b/dev/check_sklearn_1_9/_sklearn_compat_data.py
@@ -1,0 +1,67 @@
+"""
+Synthetic sample data shared across the scikit-learn compatibility checks.
+
+Each generator uses a fixed seed so the checks are deterministic. Exogenous
+data is produced with extra future rows so the prediction checks can pass future
+exog that starts one step after the training window ends.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def make_series(n: int = 120) -> pd.Series:
+    """Single univariate series with a weekly seasonal component."""
+
+    rng = np.random.default_rng(123)
+    index = pd.date_range(start="2020-01-01", periods=n, freq="D")
+    values = (
+        10
+        + np.sin(np.arange(n) * 2 * np.pi / 7)
+        + rng.normal(scale=0.5, size=n)
+    )
+    return pd.Series(values, index=index, name="y")
+
+
+def make_exog(n: int = 120, horizon: int = 5) -> pd.DataFrame:
+    """Exogenous variables covering ``n`` training points plus ``horizon`` future steps.
+
+    The extra ``horizon`` rows let the prediction checks pass future exog that
+    starts exactly one step after the training window ends.
+    """
+
+    total = n + horizon
+    rng = np.random.default_rng(456)
+    index = pd.date_range(start="2020-01-01", periods=total, freq="D")
+    return pd.DataFrame(
+        {
+            "exog_num": rng.normal(size=total),
+            "exog_cat": rng.choice(["a", "b", "c"], size=total),
+        },
+        index=index,
+    )
+
+
+def make_multi_series(n: int = 120) -> pd.DataFrame:
+    """Several series as columns, for multi-series and multivariate forecasters."""
+
+    rng = np.random.default_rng(789)
+    index = pd.date_range(start="2020-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {
+            "series_1": rng.normal(loc=10, size=n),
+            "series_2": rng.normal(loc=20, size=n),
+            "series_3": rng.normal(loc=30, size=n),
+        },
+        index=index,
+    )
+
+
+def make_class_series(n: int = 120) -> pd.Series:
+    """Integer-labelled series for the classification-based forecaster."""
+
+    rng = np.random.default_rng(321)
+    index = pd.date_range(start="2020-01-01", periods=n, freq="D")
+    return pd.Series(rng.integers(low=1, high=4, size=n), index=index, name="y")

--- a/dev/check_sklearn_1_9/_sklearn_compat_harness.py
+++ b/dev/check_sklearn_1_9/_sklearn_compat_harness.py
@@ -1,0 +1,71 @@
+"""
+Test harness for the scikit-learn compatibility check.
+
+Provides the primitives shared by all checks: the minimum supported
+scikit-learn version, the ``CheckResult`` container, version parsing, warning
+filtering, and the ``run_check`` runner that isolates scikit-learn deprecation
+warnings and errors. See ``check_sklearn_compatibility.py`` for the entry point.
+"""
+
+from __future__ import annotations
+
+import traceback
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+# Minimum scikit-learn version pinned in pyproject.toml.
+MIN_SKLEARN_VERSION = "1.4"
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single compatibility check."""
+
+    name: str
+    passed: bool
+    warnings: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+    """Convert a dotted version string into a comparable tuple of ints."""
+
+    parts = []
+    for chunk in version.split("."):
+        digits = "".join(ch for ch in chunk if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def _collect_sklearn_warnings(record: list[warnings.WarningMessage]) -> list[str]:
+    """Keep only Future/Deprecation warnings coming from scikit-learn."""
+
+    messages = []
+    for entry in record:
+        if not issubclass(entry.category, (FutureWarning, DeprecationWarning)):
+            continue
+        filename = str(entry.filename)
+        if "sklearn" not in filename and "scikit" not in filename:
+            continue
+        messages.append(f"{entry.category.__name__}: {entry.message}")
+    return messages
+
+
+def run_check(name: str, func: Callable[[], None]) -> CheckResult:
+    """Run ``func`` capturing scikit-learn deprecation warnings and errors."""
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        try:
+            func()
+        except Exception:  # noqa: BLE001 - report any failure, do not stop the run
+            return CheckResult(
+                name=name,
+                passed=False,
+                warnings=_collect_sklearn_warnings(record),
+                error=traceback.format_exc(),
+            )
+    return CheckResult(
+        name=name, passed=True, warnings=_collect_sklearn_warnings(record)
+    )

--- a/dev/check_sklearn_1_9/check_sklearn_compatibility.py
+++ b/dev/check_sklearn_1_9/check_sklearn_compatibility.py
@@ -1,0 +1,129 @@
+"""
+Scikit-learn compatibility check for skforecast
+===============================================
+
+Maintenance utility to evaluate whether the currently installed version of
+scikit-learn works correctly with skforecast. It is meant to be run whenever a
+new scikit-learn release is published, to catch deprecations, removed public
+API, and behavioural changes before they reach users.
+
+The script does not add new functionality to skforecast. It only exercises the
+public scikit-learn touch points that skforecast relies on (estimator cloning,
+``Pipeline``, ``ColumnTransformer``, estimator tags, feature selection,
+hyperparameter search, etc.) across a representative set of forecasters, and
+reports:
+
+- Installed versions of skforecast and its core dependencies.
+- Whether the installed scikit-learn satisfies the minimum pinned in
+  ``pyproject.toml`` (``scikit-learn>=1.4``).
+- Any ``FutureWarning`` / ``DeprecationWarning`` emitted by scikit-learn during
+  typical skforecast workflows.
+- Any error raised while running those workflows.
+
+The implementation is split across sibling modules in ``dev/``:
+
+- ``_sklearn_compat_harness``: ``CheckResult``, ``run_check`` and version utils.
+- ``_sklearn_compat_data``: synthetic sample data generators.
+- ``_sklearn_compat_checks``: the individual checks and the ``CHECKS`` registry.
+
+Usage
+-----
+    python dev/check_sklearn_compatibility.py
+
+Exit code is 0 when every check passes (warnings do not fail the run) and 1
+when at least one check raises an error, so the script can also be wired into
+CI if desired.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+from _sklearn_compat_checks import CHECKS
+from _sklearn_compat_harness import MIN_SKLEARN_VERSION, run_check, version_tuple
+
+
+# ----------------------------------------------------------------------------
+# Reporting
+# ----------------------------------------------------------------------------
+def _print_versions() -> str:
+    """Print installed versions and return the scikit-learn version string."""
+
+    import sklearn
+
+    import skforecast
+
+    print("Environment")
+    print("-" * 70)
+    print(f"python       : {sys.version.split()[0]}")
+    print(f"skforecast   : {skforecast.__version__}")
+    print(f"scikit-learn : {sklearn.__version__}")
+
+    for package in ("numpy", "pandas", "scipy", "joblib"):
+        try:
+            module = importlib.import_module(package)
+            print(f"{package:<12} : {module.__version__}")
+        except Exception:  # noqa: BLE001
+            print(f"{package:<12} : not installed")
+    print()
+    return sklearn.__version__
+
+
+def _check_min_version(sklearn_version: str) -> bool:
+    ok = version_tuple(sklearn_version) >= version_tuple(MIN_SKLEARN_VERSION)
+    status = "OK" if ok else "TOO OLD"
+    print(
+        f"Minimum required scikit-learn: >={MIN_SKLEARN_VERSION} "
+        f"(installed {sklearn_version}) -> {status}"
+    )
+    print()
+    return ok
+
+
+def main() -> int:
+    print("=" * 70)
+    print("skforecast <-> scikit-learn compatibility check")
+    print("=" * 70)
+
+    sklearn_version = _print_versions()
+    version_ok = _check_min_version(sklearn_version)
+
+    results = [run_check(name, func) for name, func in CHECKS.items()]
+
+    print("Checks")
+    print("-" * 70)
+    n_passed = 0
+    n_warned = 0
+    for result in results:
+        if result.passed:
+            n_passed += 1
+            marker = "WARN" if result.warnings else "PASS"
+        else:
+            marker = "FAIL"
+        print(f"[{marker}] {result.name}")
+        for message in result.warnings:
+            n_warned += 1
+            print(f"       - {message}")
+        if result.error is not None:
+            for line in result.error.strip().splitlines():
+                print(f"       {line}")
+    print()
+
+    print("Summary")
+    print("-" * 70)
+    n_total = len(results)
+    n_failed = n_total - n_passed
+    print(f"passed        : {n_passed}/{n_total}")
+    print(f"failed        : {n_failed}/{n_total}")
+    print(f"sklearn warns : {n_warned}")
+    print(f"min version   : {'satisfied' if version_ok else 'NOT satisfied'}")
+
+    all_ok = version_ok and n_failed == 0
+    print()
+    print("Result: " + ("COMPATIBLE" if all_ok else "ACTION REQUIRED"))
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/check_sklearn_1_9/sklearn_1_9_compatibility_notes.md
+++ b/dev/check_sklearn_1_9/sklearn_1_9_compatibility_notes.md
@@ -1,0 +1,159 @@
+# scikit-learn 1.9 compatibility notes for skforecast
+
+Reference: https://scikit-learn.org/stable/whats_new/v1.9.html (released June 2026).
+
+This document summarizes the scikit-learn 1.9.0 changes that are relevant to
+skforecast and lists the concrete points to verify on the skforecast side. It
+is a maintenance aid, not user-facing documentation. The automated smoke test
+lives in `dev/check_sklearn_compatibility.py`.
+
+Context: skforecast pins `scikit-learn>=1.4` (`pyproject.toml`) and wraps
+scikit-learn regressors/classifiers, relying on `clone`, estimator tags,
+`Pipeline`, `ColumnTransformer`, `OrdinalEncoder`/`OneHotEncoder`, `RFE`/`RFECV`,
+and the scorer/metric machinery.
+
+---
+
+## 1. Main scikit-learn 1.9 changes relevant to skforecast
+
+### 1.1 Dependencies and dataframe handling
+
+- **New `narwhals` dependency.** scikit-learn now uses narwhals internally to
+  support dataframe input/output in the `set_output` API. The dataframe
+  interchange protocol (`__dataframe__`), previously used for non-pandas
+  dataframes, is being retired (deprecated upstream by polars).
+- **New config key `sparse_interface`.** `set_config(sparse_interface="sparray")`
+  makes sklearn return SciPy sparse arrays instead of sparse matrices. Default
+  is still `"spmatrix"`, but will switch to `"sparray"` in a few releases.
+- **`utils.check_array` now rejects pandas `StringDtype` when `dtype="numeric"`.**
+  Under pandas 3, string columns use `StringDtype` (not `object`), which
+  previously slipped through and now raises `ValueError`.
+
+### 1.2 New deprecations (API changes)
+
+- **`criterion="friedman_mse"` deprecated in trees** (`DecisionTreeRegressor`,
+  `ExtraTreeRegressor`, `RandomForestRegressor`, `ExtraTreesRegressor`); use
+  `"squared_error"`. Also the `criterion` parameter itself is deprecated on
+  `GradientBoostingRegressor` / `GradientBoostingClassifier`.
+- **`TargetEncoder`: `shuffle` and `random_state` deprecated** (removed in 1.11);
+  pass a CV generator via `cv` instead.
+- **`SVC` / `NuSVC`: `probability` parameter deprecated** (removed in 1.11; not
+  thread-safe). Use `CalibratedClassifierCV(..., ensemble=False)`. `probA_` /
+  `probB_` attributes also deprecated.
+- **`log_loss` / `d2_log_loss_score`: `y_pred` deprecated in favor of `y_proba`.**
+- **`lasso_path` / `enet_path`: `n_alphas` deprecated.**
+- **`LogisticRegressionCV`: default `scoring` will change** from accuracy to
+  `"neg_log_loss"` in 1.11; positional `sample_weight` in `.score()` deprecated.
+- **Positional args deprecated** in `confusion_matrix_at_thresholds`
+  (`pos_label`, `sample_weight`).
+
+### 1.3 Behavioural / numeric changes ("changed models")
+
+- **`sample_weight` all-zeros now raises `ValueError`** across all estimators and
+  weight-validating metrics.
+- **RandomForest / ExtraTrees `sample_weight` semantics changed:** weights are now
+  used to draw samples; a float `max_samples` is a fraction of
+  `sample_weight.sum()` (not `X.shape[0]`), and float `max_samples > 1.0` /
+  integer `> n_samples` are now allowed. Fitted models may differ.
+- **GradientBoosting `"friedman_mse"` impurity scaling fixed** (now uses
+  `"squared_error"`); trees may differ in edge cases.
+- **`LogisticRegression(solver="lbfgs")` computes the gradient at float32** when
+  fit on float32 data (previously implicitly upcast to float64). Cast to float64
+  to reproduce old numerics.
+- **`SGDOneClassSVM` alpha formulation corrected** (`alpha = nu`); `coef_`,
+  `offset_`, and predictions may change. `SGDClassifier` NaN fix in multiclass.
+- **`RidgeCV`: `auto` is now equivalent to `eigen`** and LOO errors are numerically
+  stable in the small-alpha regime.
+- **`PowerTransformer(method="yeo-johnson")`** now uses `scipy.stats.yeojohnson`;
+  minor numeric deviations.
+
+### 1.4 Determinism / robustness (mostly positive)
+
+- **`RFE` now uses stable sorting** when ranking feature importances, so feature
+  selection is deterministic across runs when importances are tied (selected
+  features in tied cases may differ from earlier versions).
+- **`SelectFromModel` / `RFE` support sparse feature importances** via
+  `importance_getter`.
+- **`GroupKFold` uses stable sorting**; `StratifiedGroupKFold` raises when
+  `n_splits > n_groups`.
+- **`Pipeline` / `FeatureUnion` / `ColumnTransformer`** raise clearer errors when
+  an estimator class (not instance) is passed; several HTML-repr improvements.
+- **`utils.get_tags`** gives a clearer error when passed a class instead of an
+  instance.
+
+### 1.5 Low relevance to skforecast
+
+- Experimental callback API (`ProgressBar`, `ScoringMonitor`).
+- Extended Array API support across estimators/metrics.
+- Metadata routing fixes.
+- Many module-specific fixes (cluster, manifold, inspection, neighbors, etc.).
+
+---
+
+## 2. Points to check on the skforecast side
+
+### 2.1 Core wrapping and cloning
+
+- [ ] `clone`, `get_params`, `set_params` on all forecasters and wrapped
+      estimators (covered by `check_sklearn_compatibility.py`).
+- [ ] Estimator tags path: skforecast uses `__sklearn_tags__` with a legacy
+      `_get_tags` fallback. Confirm no class-vs-instance misuse now that
+      `utils.get_tags` raises on classes.
+
+### 2.2 Transformers, exog and categoricals
+
+- [ ] `transformer_y` / `transformer_series` / `transformer_exog` with
+      `Pipeline`, `ColumnTransformer`, `StandardScaler`, `OneHotEncoder`,
+      `OrdinalEncoder`.
+- [ ] `OneHotEncoder` with `set_output(transform="pandas")` requires
+      `sparse_output=False` (relevant given the `sparse_interface` config).
+- [ ] Built-in `categorical_features="auto"` (internal `OrdinalEncoder`) across
+      LightGBM / XGBoost / CatBoost / HistGradientBoosting.
+- [ ] String exog columns under pandas 3 (`StringDtype`): confirm skforecast
+      coerces/encodes before any `check_array(dtype="numeric")` path.
+
+### 2.3 Feature selection
+
+- [ ] `select_features` / `select_features_multiseries` with `RFE` / `RFECV`.
+      Stable sorting may change which lags/exog are selected in tied cases;
+      review any tests asserting exact selected-feature sets.
+
+### 2.4 Metrics and probabilistic outputs
+
+- [ ] skforecast metrics that mirror sklearn (pinball / CRPS / coverage): verify
+      no reliance on the deprecated `log_loss(y_pred=...)` signature and check
+      the `d2_pinball_score` / `d2_absolute_error_score` quantile-method change
+      if used anywhere.
+- [ ] `predict_interval` / `predict_quantiles` bootstrapping and conformal paths
+      (remember `store_in_sample_residuals=True` for conformal at fit time).
+
+### 2.5 Reproducibility of expected values in tests
+
+- [ ] RandomForest / ExtraTrees: `sample_weight` + `max_samples` semantics
+      changed. Recheck any hard-coded expected predictions in tests that use
+      these estimators with `weight_func` or `max_samples`.
+- [ ] GradientBoosting / tree estimators: avoid `criterion="friedman_mse"` in
+      examples, tests, and fixtures; switch to `"squared_error"`.
+- [ ] LogisticRegression on float32 input: expected-value drift in classifier
+      forecaster tests.
+
+### 2.6 Weights
+
+- [ ] `weight_func` / `series_weights`: ensure skforecast never forwards an
+      all-zero `sample_weight` (now a hard `ValueError`).
+
+### 2.7 Dependency surface
+
+- [ ] Confirm `narwhals` is pulled in transitively by scikit-learn (no direct
+      pin needed) and does not conflict with skforecast's environment.
+- [ ] No skforecast code relies on the deprecated `__dataframe__` interchange
+      protocol.
+
+---
+
+## 3. Status
+
+Smoke test `dev/check_sklearn_compatibility.py` run against scikit-learn 1.9.0
+(Python 3.14, numpy 2.4.6, pandas 2.3.3): 12/12 checks pass, no scikit-learn
+deprecation warnings emitted. Remaining items above are review/audit checks for
+tests, fixtures, and examples rather than confirmed breakages.

--- a/docs/quick-start/ai-assisted-forecasting.md
+++ b/docs/quick-start/ai-assisted-forecasting.md
@@ -61,7 +61,7 @@ Skforecast includes 13 modular **skills** — self-contained guides that AI agen
 | `statistical-models` | `ForecasterStats` with `Arima`, `Sarimax`, `Ets`, `Arar`: auto-ARIMA, seasonal config |
 | `hyperparameter-optimization` | Grid, random, and Bayesian search with `TimeSeriesFold` and `OneStepAheadFold` |
 | `prediction-intervals` | Bootstrapping, conformal prediction, quantile regression, interval calibration |
-| `feature-engineering` | `RollingFeatures`, feature_engine calendar/cyclical features, custom features, exogenous variables |
+| `feature-engineering` | `CalendarFeatures`, `RollingFeatures`, custom features, exogenous variables |
 | `feature-selection` | `RFECV`, `SelectFromModel`: selecting lags, window features, and exog |
 | `drift-detection` | `RangeDriftDetector` and `PopulationDriftDetector` for production monitoring |
 | `deep-learning-forecasting` | `ForecasterRnn` with Keras: `create_and_compile_model`, LSTM/GRU architectures |


### PR DESCRIPTION
- Implement individual compatibility checks for various forecasters in _sklearn_compat_checks.py.
- Create synthetic data generators in _sklearn_compat_data.py for testing.
- Develop a test harness in _sklearn_compat_harness.py to manage compatibility checks.
- Introduce a main script in check_sklearn_compatibility.py to evaluate scikit-learn compatibility with skforecast.
- Document scikit-learn 1.9 compatibility notes for skforecast in sklearn_1_9_compatibility_notes.md.
- Update AI-assisted forecasting documentation to reflect changes in feature engineering skills.