### PR TITLE
Upgrade GitHub Actions and resolve library dependency bumps

### DIFF
--- a/.github/workflows/ai-context-check.yml
+++ b/.github/workflows/ai-context-check.yml
@@ -11,7 +11,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1             # shallow clone, faster checkout
           persist-credentials: true  # use GITHUB_TOKEN for push

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
@@ -34,7 +34,7 @@ jobs:
         run: pytest --cov skforecast --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with: 
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/unit-tests-latest-deps.yml
+++ b/.github/workflows/unit-tests-latest-deps.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/dev/matplotlib_3_11_compatibility.py
+++ b/dev/matplotlib_3_11_compatibility.py
@@ -1,0 +1,116 @@
+import pytest
+import warnings
+import numpy as np
+import pandas as pd
+import matplotlib
+import matplotlib.pyplot as plt
+
+from skforecast.plot.plot import (
+    plot_residuals,
+    plot_multivariate_time_series_corr,
+    plot_prediction_distribution,
+    plot_prediction_intervals,
+    set_dark_theme,
+    backtesting_gif_creator
+)
+from skforecast.model_selection import TimeSeriesFold
+
+def test_plot_residuals_compatibility():
+    """
+    Test that `plot_residuals` executes without errors and returns a Figure.
+    """
+    y_true = np.random.normal(size=100)
+    y_pred = y_true + np.random.normal(scale=0.1, size=100)
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # Ignore irrelevant warnings during execution
+        fig = plot_residuals(y_true=y_true, y_pred=y_pred)
+        assert isinstance(fig, matplotlib.figure.Figure)
+        plt.close(fig)
+
+def test_plot_multivariate_time_series_corr_compatibility():
+    """
+    Test that `plot_multivariate_time_series_corr` executes without errors and returns a Figure.
+    """
+    corr = pd.DataFrame(np.random.rand(4, 4), columns=list('ABCD'), index=list('ABCD'))
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        fig = plot_multivariate_time_series_corr(corr=corr)
+        assert isinstance(fig, matplotlib.figure.Figure)
+        plt.close(fig)
+
+def test_plot_prediction_distribution_compatibility():
+    """
+    Test that `plot_prediction_distribution` executes without errors and returns a Figure.
+    """
+    preds = pd.DataFrame(
+        np.random.rand(5, 100), 
+        index=pd.date_range("2020-01-01", periods=5)
+    )
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        fig = plot_prediction_distribution(bootstrapping_predictions=preds)
+        assert isinstance(fig, matplotlib.figure.Figure)
+        plt.close(fig)
+
+def test_plot_prediction_intervals_compatibility():
+    """
+    Test that `plot_prediction_intervals` executes without errors and updates the given Axes.
+    """
+    preds = pd.DataFrame({
+        'pred': np.random.rand(10),
+        'lower_bound': np.random.rand(10) - 0.1,
+        'upper_bound': np.random.rand(10) + 0.1
+    }, index=pd.date_range("2020-01-01", periods=10))
+    y_true = pd.Series(np.random.rand(10), index=preds.index, name='y')
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        fig, ax = plt.subplots()
+        plot_prediction_intervals(
+            predictions=preds,
+            y_true=y_true,
+            target_variable='y',
+            ax=ax
+        )
+        assert isinstance(fig, matplotlib.figure.Figure)
+        plt.close(fig)
+
+def test_set_dark_theme_compatibility():
+    """
+    Test that `set_dark_theme` executes without errors.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        set_dark_theme()
+        # Reset to default style to avoid side effects in other tests
+        plt.style.use('default')
+
+def test_backtesting_gif_creator_compatibility(tmp_path):
+    """
+    Test that `backtesting_gif_creator` executes without errors and generates a GIF file.
+    """
+    data = pd.Series(np.random.rand(50), index=pd.date_range("2020-01-01", periods=50), name='y')
+    cv = TimeSeriesFold(
+        steps=5,
+        initial_train_size=10,
+        refit=False,
+    )
+    # Mock the window_size as it's typically set when used within a forecaster
+    cv.window_size = 5 
+    
+    file_path = tmp_path / "test_backtesting.gif"
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result_path = backtesting_gif_creator(
+            data=data,
+            cv=cv,
+            filename=str(file_path),
+            plot_last_window=True,
+            fps=1,
+            dpi=50
+        )
+        assert result_path.exists()

--- a/dev/pytorch_2_12_compatibility.py
+++ b/dev/pytorch_2_12_compatibility.py
@@ -1,0 +1,88 @@
+# ==============================================================================
+# PyTorch Compatibility Check for ForecasterRnn
+# ==============================================================================
+
+import os
+import numpy as np
+import pandas as pd
+
+# Set backend to PyTorch before importing Keras or skforecast
+os.environ["KERAS_BACKEND"] = "torch"
+
+import keras
+import torch
+from skforecast.deep_learning import ForecasterRnn
+from skforecast.deep_learning.utils import create_and_compile_model
+
+def run_compatibility_check():
+    """
+    Run a full compatibility check for PyTorch backend using ForecasterRnn.
+    """
+    print(f"Testing PyTorch version: {torch.__version__}")
+    print(f"Testing Keras version: {keras.__version__}")
+    
+    # Generate synthetic data
+    series = pd.DataFrame({
+        "level_1": pd.Series(np.random.normal(size=100)),
+        "level_2": pd.Series(np.random.normal(size=100))
+    })
+    
+    exog = pd.DataFrame({
+        "exog_1": pd.Series(np.random.normal(size=100)),
+        "exog_2": pd.Series(np.random.normal(size=100))
+    })
+
+    lags = 5
+    steps = 3
+    levels = "level_1"
+
+    # Create and compile a Keras model
+    model = create_and_compile_model(
+        series=series,
+        exog=exog,
+        levels=levels,
+        lags=lags,
+        steps=steps,
+        recurrent_layer="LSTM",
+        recurrent_units=64,
+        dense_units=32,
+    )
+
+    # Initialize ForecasterRnn
+    forecaster = ForecasterRnn(estimator=model, levels=levels, lags=lags)
+    forecaster.set_fit_kwargs({"epochs": 2, "verbose": 0})
+    
+    # Fit the model
+    print("Fitting ForecasterRnn...")
+    forecaster.fit(
+        series=series, 
+        exog=exog, 
+        store_in_sample_residuals=True
+    )
+    
+    # Check backend
+    assert forecaster.keras_backend_ == "torch", f"Expected backend 'torch', got '{forecaster.keras_backend_}'"
+    print("Backend confirmed as 'torch'.")
+
+    # Predict
+    print("Predicting...")
+    # The last_window ends at index 99, so future exog must start at 100.
+    exog_predict = pd.DataFrame({
+        "exog_1": pd.Series(np.random.normal(size=steps)),
+        "exog_2": pd.Series(np.random.normal(size=steps))
+    }, index=pd.RangeIndex(start=100, stop=100 + steps))
+    
+    predictions = forecaster.predict(steps=steps, exog=exog_predict)
+    assert not predictions.empty, "Predictions DataFrame should not be empty."
+    assert len(predictions) == steps, f"Expected {steps} predictions, got {len(predictions)}"
+    
+    # Predict Interval
+    print("Predicting intervals...")
+    predictions_interval = forecaster.predict_interval(steps=steps, exog=exog_predict)
+    assert "lower_bound" in predictions_interval.columns, "lower_bound missing from interval predictions"
+    assert "upper_bound" in predictions_interval.columns, "upper_bound missing from interval predictions"
+    
+    print("All compatibility checks passed successfully!")
+
+if __name__ == "__main__":
+    run_compatibility_check()

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -53,6 +53,10 @@ The main changes in this release are:
 
 + New `backend` parameter in <code>[save_forecaster]</code> and <code>[load_forecaster]</code> to select the serialization engine. In addition to the default `'joblib'`, the `'pickle'` and `'cloudpickle'` backends are now supported. The `'cloudpickle'` backend embeds custom functions (e.g. `weight_func`) and user-defined classes (e.g. `window_features`) directly in the saved file, removing the need to export them as separate `.py` files. A fourth `'skops'` backend provides a secure format that does not execute arbitrary code on load, recommended when loading files from untrusted sources; the new `trusted` parameter of <code>[load_forecaster]</code> controls which types skops is allowed to reconstruct (`False` by default, the secure setting). The `'skops'` backend is not available for `ForecasterStats`, `ForecasterRnn`, or `ForecasterFoundation`, whose underlying estimators embed objects that skops cannot serialize. On load, the backend is inferred automatically from the file extension (`.joblib`, `.pkl`/`.pickle`, `.cloudpickle`, `.skops`) when `backend` is not provided. [User guide](../user_guides/save-load-forecaster.ipynb)
 
++ Added `torch 2.12` compatibility.
+
++ Added `matplotlib 2.11` compatibility.
+
 
 **Changed**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,9 @@ docs = [
 
 test = [
     # Testing
-    "pytest>=7.3",
-    "pytest-cov>=4.1",
-    "pytest-xdist>=3.3",
+    "pytest>=9.1.0",
+    "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8",
     
     # Stats and plotting
     "statsmodels>=0.13, <0.15",  
@@ -131,7 +131,7 @@ Download = "https://pypi.org/project/skforecast/#files"
 Tracker = "https://github.com/skforecast/skforecast/issues"
 
 [build-system]
-requires = ["setuptools>=61", "toml", "build"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,17 +70,17 @@ stats = [
 ]
 
 plotting = [
-    "matplotlib>=3.7, <3.11",
+    "matplotlib>=3.7, <3.12",
     "statsmodels>=0.13, <0.15"
 ]
 
 deeplearning = [
     "keras>=3.0, <4.0",
-    "matplotlib>=3.7, <3.11",
+    "matplotlib>=3.7, <3.12",
 ]
 
 all = [
-    "matplotlib>=3.7, <3.11",
+    "matplotlib>=3.7, <3.12",
     "statsmodels>=0.13, <0.15",
     "keras>=3.0, <4.0",
     'tensorflow>=2.18, <2.22; python_version < "3.14"',
@@ -107,7 +107,7 @@ test = [
     
     # Stats and plotting
     "statsmodels>=0.13, <0.15",  
-    "matplotlib>=3.7, <3.11",
+    "matplotlib>=3.7, <3.12",
     
     # Other optional dependencies
     "lightgbm>=4.0, <5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ all = [
     "statsmodels>=0.13, <0.15",
     "keras>=3.0, <4.0",
     'tensorflow>=2.18, <2.22; python_version < "3.14"',
-    "torch>=2.4, <2.12"
+    "torch>=2.4, <2.13"
 ]
 
 full = ["skforecast[all]"]
@@ -114,7 +114,7 @@ test = [
     "xgboost>=2.1, <4.0",
     "catboost>=1.2, <2.0",
     "keras>=3.0, <4.0",
-    "torch>=2.4, <2.12",
+    "torch>=2.4, <2.13",
     "cloudpickle>=3.0",
     "skops>=0.14",
     "tomli>=2.0",


### PR DESCRIPTION
Update the codecov/codecov-action step from uses: codecov/codecov-action@v6 to uses: codecov/codecov-action@v7. Version 7 addresses a GPG verification key migration (switching from the codecovsecurity to the codecovsecops Keybase account).

Update the five .github/workflows/*.yml files to update the actions/checkout action version. The v7 release explicitly blocks checking out fork PRs during potentially dangerous workflow events (pull_request_target and workflow_run). This prevents malicious actors from executing unreviewed code with elevated repository permissions.

build-system.requires was updated from '["setuptools>=61", "toml", "build"]' to '["setuptools>=83.0.0"]': the unused toml and build packages were dropped, and the setuptools floor was raised to match the PEP 639 license/license-files syntax already in use (needs setuptools ≥77).

The pytest stack (pytest>=9.1.0, pytest-cov>=7.1.0, and pytest-xdist>=3.8) was bumped to its latest minimum versions, incorporating upstream bug and dependency vulnerability fixes accumulated since the previous versions and maintaining a more actively maintained and secure baseline for the test suite.

Allow and verify compatibility with the last release of torch 2.12

Allow and verify compatibility with the last release of matplotlib 2.11

Verify that the subsequent Codecov coverage workflow run executes successfully and correctly uploads the coverage report.

Verify that all GitHub Actions run properly.

Ensure that all unit tests pass in Linux, macOS and Windows for Python 3.10 to 3.14.